### PR TITLE
Corrigido o carregamento indevido de dados entre usuários na página de resultado da análise.

### DIFF
--- a/frontend/src/app/compatibility/page.tsx
+++ b/frontend/src/app/compatibility/page.tsx
@@ -68,7 +68,14 @@ export default function CompatibilityPage() {
       recommendation: buildRecommendation(compat.selections.selectedRequired, compat.selections.selectedOptional),
     }
 
-    window.sessionStorage.setItem('analysisResult', JSON.stringify(analysisData))
+    const usuarioLogado = JSON.parse(
+      localStorage.getItem('usuarioLogado') || '{}'
+    )
+
+    window.sessionStorage.setItem(
+      `analysisResult_${usuarioLogado.email}`,
+      JSON.stringify(analysisData)
+    )
 
     navigate('/analise', { replace: true })
   }

--- a/frontend/src/app/resultado-analise/page.tsx
+++ b/frontend/src/app/resultado-analise/page.tsx
@@ -21,15 +21,24 @@ import type { AnalysisResult } from './types'
 
 function getStoredAnalysisData(): AnalysisResult | null {
   try {
-    const stored = window.sessionStorage.getItem('analysisResult')
+    const usuarioLogado = JSON.parse(
+      localStorage.getItem('usuarioLogado') || '{}'
+    )
+
+    const stored = window.sessionStorage.getItem(
+      `analysisResult_${usuarioLogado.email}`
+    )
+
     if (stored) {
       return JSON.parse(stored) as AnalysisResult
     }
   } catch (e) {
     console.error('Failed to parse analysis data:', e)
   }
+
   return null
 }
+
 
 export default function ResultadoAnalisePage() {
   const navigate = useNavigate()


### PR DESCRIPTION
Agora os resultados das análises são armazenados de forma individual por usuário, utilizando o e-mail da conta logada como identificador no sessionStorage. Antes da correção, análises realizadas por um usuário podiam aparecer para outros usuários no mesmo navegador.