### PR TITLE
fix(study-plan): nao incluir skills ja dominadas e garantir subskills…

### DIFF
--- a/ai_service/app/agents/plano_estudo.py
+++ b/ai_service/app/agents/plano_estudo.py
@@ -191,8 +191,12 @@ def _normalize_ai_items(parsed: dict, job_skills: list[dict], user_skills: list[
 		if not job_skill or skill_key in seen:
 			continue
 
-		current_level = _normalize_level(item.get("current_level"), user_levels.get(skill_key))
+		# Trust the user-provided level over whatever the model guesses.
+		current_level = user_levels.get(skill_key)
 		target_level = _normalize_level(item.get("target_level"), _normalize_level(job_skill.get("required_level"), "Basic"))
+		required_level = _normalize_level(job_skill.get("required_level"), "Basic")
+		if _level_index(current_level) >= _level_index(required_level):
+			continue
 		if _level_index(current_level) >= _level_index(target_level):
 			continue
 
@@ -228,8 +232,12 @@ def generate_study_plan(
 	prompt = prompt.replace("{job_skills}", _json_dumps(job_skills))
 	prompt = prompt.replace("{user_skills}", _json_dumps(user_skills))
 
+	# Bail out when the backend has already filtered the gap to nothing.
+	if not job_skills:
+		return {"items": []}
+
 	try:
-		response = ask_hf(prompt, max_tokens=1200)
+		response = ask_hf(prompt, max_tokens=2400)
 		parsed = _parse_model_response(response)
 		items = _normalize_ai_items(parsed, job_skills, user_skills)
 	except Exception:

--- a/ai_service/app/prompts/plano_prompt.txt
+++ b/ai_service/app/prompts/plano_prompt.txt
@@ -1,27 +1,36 @@
 You are generating a study plan for GapDev.
 Each plan is made of modules. Each module corresponds to ONE skill the job
-requires that the user is missing or has below the required level. Inside each
-module you must break that skill down into the concrete sub-skills (learning
-topics) the user has to learn so the module skill can be considered mastered.
+requires that the user is still missing. Inside each module you must break
+that skill down into the concrete sub-skills (learning topics) the user must
+learn so the module skill can be considered mastered.
+
+The "Job skills" payload below ONLY contains the skills the user does NOT
+already meet. The "User skills" payload is provided as background only — never
+emit a module for any skill the user already has at or above the required
+level. If "Job skills" is empty, return {"items":[]}.
 
 Return only valid JSON in this exact shape:
 {"items":[{"skill_id":"string","current_level":"Beginner|Basic|Intermediate|Advanced|Specialist|null","target_level":"Basic|Intermediate|Advanced|Specialist","priority":"required|desirable","reason":"string","subskills":[{"name":"string","reason":"string"}]}]}
 
 Rules:
-- Use only skill_id values present in the job_skills list for the module skill_id.
-- Include only modules where the user is missing the skill or current_level is lower than target_level.
+- skill_id MUST be one of the skill_id values in the Job skills payload.
+- One module per skill_id, no duplicates.
 - target_level must be at least the job required_level for that skill.
-- priority must be "required" for mandatory skills and "desirable" for optional skills.
-- subskills must list 2 to 5 concrete learning topics needed to master the module skill.
-- subskills[].name is a short topic title (e.g. "Hooks no React", "Async/await em Python"). Do NOT invent skill_id values for subskills, only names.
-- Every text field (reason, subskills[].reason) must be concise, practical, and written in Brazilian Portuguese.
+- priority must mirror the priority in the Job skills payload.
+- subskills MUST contain between 3 and 5 specific learning topics needed to
+  master the module skill. Topics must be concrete and actionable
+  (e.g. "Hooks no React", "Decorators em Python", "Promises e async/await").
+- subskills[].name MUST NOT repeat the module skill name verbatim.
+- Do NOT invent skill_id values for subskills, only names.
+- Every text field (reason, subskills[].reason) must be concise, practical and
+  written in Brazilian Portuguese.
 - Return at most 8 modules.
 
 Job:
 {job_context}
 
-Job skills:
+Job skills (the gap, only what the user is missing):
 {job_skills}
 
-User skills:
+User skills (context only — never include these as modules):
 {user_skills}

--- a/backend/app/repositories/job_skill_repository.py
+++ b/backend/app/repositories/job_skill_repository.py
@@ -116,26 +116,38 @@ def get_or_create_skill(db: Session, raw_name: str) -> Skill:
 SUBTOPIC_CATEGORY = "Subtopico"
 
 
-def resolve_or_create_subtopic_skill(db: Session, raw_name: str) -> Skill | None:
-	"""Resolve a learning topic to a catalog skill, creating it when needed.
+def _unique_subtopic_slug(db: Session, base_slug: str) -> str:
+	"""Return a slug guaranteed to be free in the skills table."""
 
-	Reuses an existing canonical skill when the name matches the catalog
-	(by name, slug or alias). Otherwise registers a new granular study topic
-	flagged as inactive and categorized as a subtopic, so it keeps the skill
-	pattern without polluting the user-facing catalog or the job matching.
+	import secrets
+
+	candidate = f"{base_slug}-sub"
+	while get_skill_by_slug(db, candidate) is not None:
+		candidate = f"{base_slug}-sub-{secrets.token_hex(3)}"
+	return candidate
+
+
+def resolve_or_create_subtopic_skill(db: Session, raw_name: str, module_name: str | None = None) -> Skill | None:
+	"""Register a granular learning topic as a catalog skill.
+
+	Each call creates a brand new inactive subtopic entry (category
+	"Subtopico"). Subtopics are study-scoped granular topics — reusing
+	canonical catalog skills would pollute the user-facing catalog and break
+	the per-module learning context, so we always materialize a new row.
 	"""
 
 	clean_name = (raw_name or "").strip()
 	if not clean_name:
 		return None
 
-	existing = resolve_catalog_skill(db, None, clean_name)
-	if existing:
-		return existing
+	canonical_name = clean_name
+	base_slug = _normalize_skill_slug(clean_name)
+	if module_name:
+		base_slug = f"{_normalize_skill_slug(module_name)}-{base_slug}"
 
 	skill = Skill(
-		canonical_name=clean_name,
-		slug=_normalize_skill_slug(clean_name),
+		canonical_name=canonical_name,
+		slug=_unique_subtopic_slug(db, base_slug),
 		category=SUBTOPIC_CATEGORY,
 		active=False,
 	)
@@ -145,12 +157,16 @@ def resolve_or_create_subtopic_skill(db: Session, raw_name: str) -> Skill | None
 	return skill
 
 
+def _is_subtopic(skill: Skill | None) -> bool:
+	return bool(skill) and getattr(skill, "category", None) == SUBTOPIC_CATEGORY
+
+
 def resolve_catalog_skill(db: Session, skill_id: str | None = None, raw_name: str | None = None) -> Skill | None:
-	"""Resolve a catalog skill without creating new records."""
+	"""Resolve a public catalog skill (subtopics are ignored on purpose)."""
 
 	if skill_id:
 		skill = get_skill_by_id(db, skill_id)
-		if skill:
+		if skill and not _is_subtopic(skill):
 			return skill
 
 	if not raw_name:
@@ -161,14 +177,18 @@ def resolve_catalog_skill(db: Session, skill_id: str | None = None, raw_name: st
 		return None
 
 	skill = get_skill_by_canonical_name(db, clean_name)
-	if skill:
+	if skill and not _is_subtopic(skill):
 		return skill
 
 	skill = get_skill_by_slug(db, _normalize_skill_slug(clean_name))
-	if skill:
+	if skill and not _is_subtopic(skill):
 		return skill
 
-	return get_skill_by_normalized_alias(db, normalize_skill_alias_key(clean_name))
+	skill = get_skill_by_normalized_alias(db, normalize_skill_alias_key(clean_name))
+	if skill and not _is_subtopic(skill):
+		return skill
+
+	return None
 
 def list_active_skills(db: Session) -> list[Skill]:
 	"""Return active catalog skills sorted by category and name."""

--- a/backend/app/services/study_plan_service.py
+++ b/backend/app/services/study_plan_service.py
@@ -155,38 +155,77 @@ def _user_skills_for_ai(user_skills: list[object]) -> list[dict]:
 	return items
 
 
-def _resolve_subskills(db: Session, subskills: object, module_skill_id: str) -> list[dict]:
-	"""Resolve generated learning topics into catalog-backed sub-skill rows."""
+def _fallback_subskill_names(module_name: str) -> list[dict]:
+	"""Generic learning topics used when the model omits a module breakdown."""
 
-	resolved: list[dict] = []
-	seen: set[str] = set()
+	return [
+		{"name": f"Fundamentos de {module_name}", "reason": f"Dominar os conceitos basicos de {module_name}."},
+		{"name": f"Pratica guiada de {module_name}", "reason": f"Aplicar {module_name} em exercicios praticos."},
+		{"name": f"Projeto com {module_name}", "reason": f"Consolidar o aprendizado de {module_name} em um projeto."},
+	]
+
+
+def _resolve_subskills(db: Session, subskills: object, module_skill_id: str, module_name: str) -> list[dict]:
+	"""Resolve generated learning topics into freshly created subtopic skills."""
+
+	module_key = module_name.strip().lower()
+	candidates: list[dict] = []
+	seen_names: set[str] = {module_key} if module_key else set()
 	for subskill in subskills or []:
-		if not isinstance(subskill, dict):
-			continue
+		if isinstance(subskill, dict):
+			name = str(subskill.get("name") or subskill.get("skill_name") or "").strip()
+			reason = subskill.get("reason")
+		else:
+			name = str(subskill or "").strip()
+			reason = None
 
-		name = str(subskill.get("name") or "").strip()
 		if not name:
 			continue
 
-		catalog_skill = resolve_or_create_subtopic_skill(db, name)
+		key = name.lower()
+		if key in seen_names:
+			continue
+		seen_names.add(key)
+		candidates.append({"name": name, "reason": reason})
+
+	if not candidates:
+		candidates = _fallback_subskill_names(module_name)
+
+	resolved: list[dict] = []
+	for candidate in candidates[:5]:
+		catalog_skill = resolve_or_create_subtopic_skill(db, candidate["name"], module_name)
 		if not catalog_skill:
 			continue
-
-		skill_key = str(catalog_skill.id)
-		# A sub-skill must not duplicate the module skill nor a sibling topic.
-		if skill_key == module_skill_id or skill_key in seen:
+		if str(catalog_skill.id) == module_skill_id:
 			continue
-
 		resolved.append(
 			{
-				"skill_id": skill_key,
-				"reason": subskill.get("reason"),
+				"skill_id": str(catalog_skill.id),
+				"reason": candidate.get("reason"),
 				"status": "pending",
 			}
 		)
-		seen.add(skill_key)
 
 	return resolved
+
+
+def _filter_missing_job_skills(job_skills: list[object], user_skills: list[object]) -> list[object]:
+	"""Drop job skills the user already meets at or above the required level."""
+
+	user_level_by_skill_id = {
+		str(getattr(us, "skill_id")): _enum_value(getattr(us, "level", None))
+		for us in user_skills
+	}
+
+	missing: list[object] = []
+	for job_skill in job_skills:
+		skill_key = str(getattr(job_skill, "skill_id"))
+		required = _enum_value(getattr(job_skill, "required_level", SkillLevel.Basic))
+		current = user_level_by_skill_id.get(skill_key)
+		if _level_index(current) >= _level_index(required):
+			continue
+		missing.append(job_skill)
+	return missing
 
 
 def _normalize_generated_items(db: Session, generated_items: list[dict], job_skills: list[object], user_skills: list[object]) -> list[dict]:
@@ -210,12 +249,23 @@ def _normalize_generated_items(db: Session, generated_items: list[dict], job_ski
 		if not job_skill or skill_key in seen:
 			continue
 
+		# Always trust the user's recorded level over what the AI claims.
 		user_skill = user_skill_by_id.get(skill_key)
-		current_level = item.get("current_level") or _enum_value(getattr(user_skill, "level", None))
+		current_level = _enum_value(getattr(user_skill, "level", None))
 		target_level = item.get("target_level") or _enum_value(getattr(job_skill, "required_level", SkillLevel.Basic))
 
+		# Hard gate: user already meets/exceeds the required level.
+		required_level = _enum_value(getattr(job_skill, "required_level", SkillLevel.Basic))
+		if _level_index(current_level) >= _level_index(required_level):
+			continue
 		if _level_index(current_level) >= _level_index(target_level):
 			continue
+
+		module_name = (
+			str(getattr(getattr(job_skill, "skill", None), "canonical_name", ""))
+			or str(getattr(job_skill, "raw_name", ""))
+			or "esta habilidade"
+		)
 
 		normalized.append(
 			{
@@ -225,12 +275,38 @@ def _normalize_generated_items(db: Session, generated_items: list[dict], job_ski
 				"priority": item.get("priority") or _enum_value(getattr(job_skill, "priority", "desirable")),
 				"reason": item.get("reason"),
 				"status": "pending",
-				"subskills": _resolve_subskills(db, item.get("subskills"), skill_key),
+				"subskills": _resolve_subskills(db, item.get("subskills"), skill_key, module_name),
 			}
 		)
 		seen.add(skill_key)
 
 	return normalized
+
+
+def _items_from_missing_skills(db: Session, missing_job_skills: list[object]) -> list[dict]:
+	"""Backstop plan built directly from the gap, when the AI returns nothing."""
+
+	items: list[dict] = []
+	for job_skill in missing_job_skills:
+		skill_key = str(getattr(job_skill, "skill_id"))
+		module_name = (
+			str(getattr(getattr(job_skill, "skill", None), "canonical_name", ""))
+			or str(getattr(job_skill, "raw_name", ""))
+			or "esta habilidade"
+		)
+		target_level = _enum_value(getattr(job_skill, "required_level", SkillLevel.Basic))
+		items.append(
+			{
+				"skill_id": skill_key,
+				"current_level": None,
+				"target_level": target_level,
+				"priority": _enum_value(getattr(job_skill, "priority", "desirable")),
+				"reason": f"Desenvolver {module_name} para atender o nivel {target_level} exigido pela vaga.",
+				"status": "pending",
+				"subskills": _resolve_subskills(db, None, skill_key, module_name),
+			}
+		)
+	return items
 
 
 def generate_plan_for_job(db: Session, user_email: str, job_id: str, force_regenerate: bool = False) -> StudyPlanRead:
@@ -251,6 +327,14 @@ def generate_plan_for_job(db: Session, user_email: str, job_id: str, force_regen
 		)
 
 	user_skills = list_skills_by_user(db, user_id)
+
+	# Only ask the AI about the actual gap so it can't waste tokens on
+	# skills the user already meets at or above the required level.
+	missing_job_skills = _filter_missing_job_skills(job_skills, user_skills)
+	if not missing_job_skills:
+		plan = create_or_replace_study_plan(db, user_id, job_id, [], "completed")
+		return _plan_to_read(plan)
+
 	ai_payload = generate_study_plan(
 		job_context={
 			"job_id": str(job.id),
@@ -258,12 +342,18 @@ def generate_plan_for_job(db: Session, user_email: str, job_id: str, force_regen
 			"company": str(job.company_name),
 			"level": _enum_value(getattr(job, "level", None)),
 		},
-		job_skills=_job_skills_for_ai(job_skills),
+		job_skills=_job_skills_for_ai(missing_job_skills),
 		user_skills=_user_skills_for_ai(user_skills),
 	)
 
 	generated_items = ai_payload.get("items", []) if isinstance(ai_payload, dict) else []
-	items = _normalize_generated_items(db, generated_items, job_skills, user_skills)
+	items = _normalize_generated_items(db, generated_items, missing_job_skills, user_skills)
+
+	# Backstop: if the model returned nothing usable, build the plan
+	# directly from the gap so the user is never left without modules.
+	if not items:
+		items = _items_from_missing_skills(db, missing_job_skills)
+
 	plan_status = "active" if items else "completed"
 	plan = create_or_replace_study_plan(db, user_id, job_id, items, plan_status)
 	return _plan_to_read(plan)


### PR DESCRIPTION
… no banco

Dois bugs reportados:
- planos incluiam skills que o usuario ja possuia no nivel exigido pela vaga
- nenhuma linha em skills com categoria "Subtopico" era criada

Causas:
- o normalizador confiava no current_level inventado pela IA; quando ele vinha como "Beginner" ou ausente, skills ja dominadas escapavam do filtro
- subtopicos eram resolvidos via resolve_catalog_skill e quase sempre batiam com canonical_names existentes (ex: "JavaScript" como topico de React), o que reaproveitava a skill canonica e nunca persistia novas rows

Correcoes:
- pre-filtrar job_skills antes de chamar a IA: a IA so ve a real lacuna
- usar SEMPRE o nivel real do usuario (ignorar current_level da IA) e re-checar contra required_level no agent e no service
- subtopicos agora sao SEMPRE criados como nova row (categoria "Subtopico", inativos), com slug unico prefixado pelo modulo
- resolve_catalog_skill passa a ignorar subtopicos -> nao vazam para matching de vagas nem para cadastro de skills do usuario
- backstop: se a IA retornar lista vazia, geramos modulos a partir da lacuna
- prompt mais explicito: a IA so recebe a lacuna real e nao deve emitir nada para skills ja dominadas
- bloquear topico com mesmo nome do modulo (case-insensitive)
- aumentar max_tokens para 2400 (8 modulos x ate 5 subskills cabia apertado)