### PR TITLE
Add granular learning topics (subskills) to study plans

### DIFF
--- a/ai_service/app/agents/plano_estudo.py
+++ b/ai_service/app/agents/plano_estudo.py
@@ -67,6 +67,58 @@ def _json_dumps(data: Any) -> str:
 	return json.dumps(data, ensure_ascii=False, indent=2)
 
 
+def _normalize_subskills(raw_subskills: Any, skill_name: str, target_level: str) -> list[dict]:
+	"""Keep only well-formed learning topics for a module."""
+
+	topics: list[dict] = []
+	seen: set[str] = set()
+	if isinstance(raw_subskills, list):
+		for topic in raw_subskills:
+			if isinstance(topic, dict):
+				name = str(topic.get("name") or topic.get("skill_name") or "").strip()
+				reason = str(topic.get("reason") or "").strip()
+			else:
+				name = str(topic or "").strip()
+				reason = ""
+
+			if not name:
+				continue
+
+			key = name.lower()
+			if key in seen:
+				continue
+
+			if not reason:
+				reason = f"Aprender {name} para dominar {skill_name}."
+
+			topics.append({"name": name[:255], "reason": reason[:500]})
+			seen.add(key)
+
+	if not topics:
+		topics = _fallback_subskills(skill_name, target_level)
+
+	return topics[:5]
+
+
+def _fallback_subskills(skill_name: str, target_level: str) -> list[dict]:
+	"""Generic learning topics used when the model omits a module breakdown."""
+
+	return [
+		{
+			"name": f"Fundamentos de {skill_name}",
+			"reason": f"Dominar os conceitos basicos de {skill_name}.",
+		},
+		{
+			"name": f"Pratica de {skill_name}",
+			"reason": f"Praticar {skill_name} ate o nivel {target_level} com exercicios reais.",
+		},
+		{
+			"name": f"Projeto com {skill_name}",
+			"reason": f"Aplicar {skill_name} em um projeto para consolidar o aprendizado.",
+		},
+	]
+
+
 def _fallback_items(job_skills: Iterable[dict], user_skills: Iterable[dict]) -> list[dict]:
 	user_levels = {
 		str(skill.get("skill_id")): _normalize_level(skill.get("level"))
@@ -96,10 +148,11 @@ def _fallback_items(job_skills: Iterable[dict], user_skills: Iterable[dict]) -> 
 				"target_level": target_level,
 				"priority": _normalize_priority(skill.get("priority")),
 				"reason": f"Desenvolver {skill_name} ate o nivel {target_level} para cobrir a lacuna desta vaga.",
+				"subskills": _fallback_subskills(skill_name, target_level),
 			}
 		)
 
-	return items[:10]
+	return items[:8]
 
 
 def _normalize_ai_items(parsed: dict, job_skills: list[dict], user_skills: list[dict]) -> list[dict]:
@@ -143,9 +196,9 @@ def _normalize_ai_items(parsed: dict, job_skills: list[dict], user_skills: list[
 		if _level_index(current_level) >= _level_index(target_level):
 			continue
 
+		skill_name = job_skill.get("skill_name") or job_skill.get("raw_name") or "esta habilidade"
 		reason = str(item.get("reason") or "").strip()
 		if not reason:
-			skill_name = job_skill.get("skill_name") or job_skill.get("raw_name") or "esta habilidade"
 			reason = f"Desenvolver {skill_name} ate o nivel {target_level} para atender melhor a vaga."
 
 		normalized.append(
@@ -155,11 +208,12 @@ def _normalize_ai_items(parsed: dict, job_skills: list[dict], user_skills: list[
 				"target_level": target_level,
 				"priority": _normalize_priority(item.get("priority"), _normalize_priority(job_skill.get("priority"))),
 				"reason": reason[:500],
+				"subskills": _normalize_subskills(item.get("subskills"), skill_name, target_level),
 			}
 		)
 		seen.add(skill_key)
 
-	return normalized[:10]
+	return normalized[:8]
 
 
 def generate_study_plan(

--- a/ai_service/app/agents/plano_estudo.py
+++ b/ai_service/app/agents/plano_estudo.py
@@ -191,8 +191,12 @@ def _normalize_ai_items(parsed: dict, job_skills: list[dict], user_skills: list[
 		if not job_skill or skill_key in seen:
 			continue
 
-		current_level = _normalize_level(item.get("current_level"), user_levels.get(skill_key))
+		# Trust the user-provided level over whatever the model guesses.
+		current_level = user_levels.get(skill_key)
 		target_level = _normalize_level(item.get("target_level"), _normalize_level(job_skill.get("required_level"), "Basic"))
+		required_level = _normalize_level(job_skill.get("required_level"), "Basic")
+		if _level_index(current_level) >= _level_index(required_level):
+			continue
 		if _level_index(current_level) >= _level_index(target_level):
 			continue
 
@@ -228,8 +232,12 @@ def generate_study_plan(
 	prompt = prompt.replace("{job_skills}", _json_dumps(job_skills))
 	prompt = prompt.replace("{user_skills}", _json_dumps(user_skills))
 
+	# Bail out when the backend has already filtered the gap to nothing.
+	if not job_skills:
+		return {"items": []}
+
 	try:
-		response = ask_hf(prompt, max_tokens=1200)
+		response = ask_hf(prompt, max_tokens=2400)
 		parsed = _parse_model_response(response)
 		items = _normalize_ai_items(parsed, job_skills, user_skills)
 	except Exception:

--- a/ai_service/app/agents/plano_estudo.py
+++ b/ai_service/app/agents/plano_estudo.py
@@ -120,8 +120,8 @@ def _fallback_subskills(skill_name: str, target_level: str) -> list[dict]:
 
 
 def _fallback_items(job_skills: Iterable[dict], user_skills: Iterable[dict]) -> list[dict]:
-	user_levels = {
-		str(skill.get("skill_id")): _normalize_level(skill.get("level"))
+	known_skill_ids = {
+		str(skill.get("skill_id"))
 		for skill in user_skills
 		if isinstance(skill, dict) and skill.get("skill_id")
 	}
@@ -135,10 +135,12 @@ def _fallback_items(job_skills: Iterable[dict], user_skills: Iterable[dict]) -> 
 		if not skill_id:
 			continue
 
-		target_level = _normalize_level(skill.get("required_level"), "Basic")
-		current_level = user_levels.get(str(skill_id))
-		if _level_index(current_level) >= _level_index(target_level):
+		# Only skills the user does not know belong in the plan.
+		if str(skill_id) in known_skill_ids:
 			continue
+
+		target_level = _normalize_level(skill.get("required_level"), "Basic")
+		current_level = None
 
 		skill_name = skill.get("skill_name") or skill.get("raw_name") or "esta habilidade"
 		items.append(
@@ -170,8 +172,8 @@ def _normalize_ai_items(parsed: dict, job_skills: list[dict], user_skills: list[
 		for skill in job_skills
 		if isinstance(skill, dict) and skill.get("skill_id")
 	}
-	user_levels = {
-		str(skill.get("skill_id")): _normalize_level(skill.get("level"))
+	known_skill_ids = {
+		str(skill.get("skill_id"))
 		for skill in user_skills
 		if isinstance(skill, dict) and skill.get("skill_id")
 	}
@@ -191,14 +193,12 @@ def _normalize_ai_items(parsed: dict, job_skills: list[dict], user_skills: list[
 		if not job_skill or skill_key in seen:
 			continue
 
-		# Trust the user-provided level over whatever the model guesses.
-		current_level = user_levels.get(skill_key)
+		# Only skills the user does not know belong in the plan.
+		if skill_key in known_skill_ids:
+			continue
+
+		current_level = None
 		target_level = _normalize_level(item.get("target_level"), _normalize_level(job_skill.get("required_level"), "Basic"))
-		required_level = _normalize_level(job_skill.get("required_level"), "Basic")
-		if _level_index(current_level) >= _level_index(required_level):
-			continue
-		if _level_index(current_level) >= _level_index(target_level):
-			continue
 
 		skill_name = job_skill.get("skill_name") or job_skill.get("raw_name") or "esta habilidade"
 		reason = str(item.get("reason") or "").strip()

--- a/ai_service/app/prompts/plano_prompt.txt
+++ b/ai_service/app/prompts/plano_prompt.txt
@@ -1,14 +1,21 @@
 You are generating a study plan for GapDev.
+Each plan is made of modules. Each module corresponds to ONE skill the job
+requires that the user is missing or has below the required level. Inside each
+module you must break that skill down into the concrete sub-skills (learning
+topics) the user has to learn so the module skill can be considered mastered.
+
 Return only valid JSON in this exact shape:
-{"items":[{"skill_id":"string","current_level":"Beginner|Basic|Intermediate|Advanced|Specialist|null","target_level":"Basic|Intermediate|Advanced|Specialist","priority":"required|desirable","reason":"string"}]}
+{"items":[{"skill_id":"string","current_level":"Beginner|Basic|Intermediate|Advanced|Specialist|null","target_level":"Basic|Intermediate|Advanced|Specialist","priority":"required|desirable","reason":"string","subskills":[{"name":"string","reason":"string"}]}]}
 
 Rules:
-- Use only skill_id values present in the job_skills list.
-- Include only skills where the user is missing the skill or current_level is lower than target_level.
+- Use only skill_id values present in the job_skills list for the module skill_id.
+- Include only modules where the user is missing the skill or current_level is lower than target_level.
 - target_level must be at least the job required_level for that skill.
 - priority must be "required" for mandatory skills and "desirable" for optional skills.
-- reason must be concise, practical, and written in Brazilian Portuguese.
-- Return at most 10 items.
+- subskills must list 2 to 5 concrete learning topics needed to master the module skill.
+- subskills[].name is a short topic title (e.g. "Hooks no React", "Async/await em Python"). Do NOT invent skill_id values for subskills, only names.
+- Every text field (reason, subskills[].reason) must be concise, practical, and written in Brazilian Portuguese.
+- Return at most 8 modules.
 
 Job:
 {job_context}

--- a/ai_service/app/prompts/plano_prompt.txt
+++ b/ai_service/app/prompts/plano_prompt.txt
@@ -1,27 +1,36 @@
 You are generating a study plan for GapDev.
 Each plan is made of modules. Each module corresponds to ONE skill the job
-requires that the user is missing or has below the required level. Inside each
-module you must break that skill down into the concrete sub-skills (learning
-topics) the user has to learn so the module skill can be considered mastered.
+requires that the user is still missing. Inside each module you must break
+that skill down into the concrete sub-skills (learning topics) the user must
+learn so the module skill can be considered mastered.
+
+The "Job skills" payload below ONLY contains the skills the user does NOT
+already meet. The "User skills" payload is provided as background only — never
+emit a module for any skill the user already has at or above the required
+level. If "Job skills" is empty, return {"items":[]}.
 
 Return only valid JSON in this exact shape:
 {"items":[{"skill_id":"string","current_level":"Beginner|Basic|Intermediate|Advanced|Specialist|null","target_level":"Basic|Intermediate|Advanced|Specialist","priority":"required|desirable","reason":"string","subskills":[{"name":"string","reason":"string"}]}]}
 
 Rules:
-- Use only skill_id values present in the job_skills list for the module skill_id.
-- Include only modules where the user is missing the skill or current_level is lower than target_level.
+- skill_id MUST be one of the skill_id values in the Job skills payload.
+- One module per skill_id, no duplicates.
 - target_level must be at least the job required_level for that skill.
-- priority must be "required" for mandatory skills and "desirable" for optional skills.
-- subskills must list 2 to 5 concrete learning topics needed to master the module skill.
-- subskills[].name is a short topic title (e.g. "Hooks no React", "Async/await em Python"). Do NOT invent skill_id values for subskills, only names.
-- Every text field (reason, subskills[].reason) must be concise, practical, and written in Brazilian Portuguese.
+- priority must mirror the priority in the Job skills payload.
+- subskills MUST contain between 3 and 5 specific learning topics needed to
+  master the module skill. Topics must be concrete and actionable
+  (e.g. "Hooks no React", "Decorators em Python", "Promises e async/await").
+- subskills[].name MUST NOT repeat the module skill name verbatim.
+- Do NOT invent skill_id values for subskills, only names.
+- Every text field (reason, subskills[].reason) must be concise, practical and
+  written in Brazilian Portuguese.
 - Return at most 8 modules.
 
 Job:
 {job_context}
 
-Job skills:
+Job skills (the gap, only what the user is missing):
 {job_skills}
 
-User skills:
+User skills (context only — never include these as modules):
 {user_skills}

--- a/ai_service/app/prompts/plano_prompt.txt
+++ b/ai_service/app/prompts/plano_prompt.txt
@@ -4,10 +4,10 @@ requires that the user is still missing. Inside each module you must break
 that skill down into the concrete sub-skills (learning topics) the user must
 learn so the module skill can be considered mastered.
 
-The "Job skills" payload below ONLY contains the skills the user does NOT
-already meet. The "User skills" payload is provided as background only — never
-emit a module for any skill the user already has at or above the required
-level. If "Job skills" is empty, return {"items":[]}.
+The "Job skills" payload below ONLY contains skills the user does NOT have in
+their profile yet. The "User skills" payload is provided as background only —
+never emit a module for any skill already present in the user's profile,
+regardless of level. If "Job skills" is empty, return {"items":[]}.
 
 Return only valid JSON in this exact shape:
 {"items":[{"skill_id":"string","current_level":"Beginner|Basic|Intermediate|Advanced|Specialist|null","target_level":"Basic|Intermediate|Advanced|Specialist","priority":"required|desirable","reason":"string","subskills":[{"name":"string","reason":"string"}]}]}

--- a/backend/app/api/routes/study_plan.py
+++ b/backend/app/api/routes/study_plan.py
@@ -5,8 +5,20 @@ from sqlalchemy.orm import Session
 
 from app.api.deps import get_current_user, get_database
 from app.models.user import User
-from app.schemas.study_plan import StudyPlanGenerateRequest, StudyPlanItemRead, StudyPlanItemStatusUpdate, StudyPlanRead
-from app.services.study_plan_service import generate_plan_for_job, get_plan_for_job, list_plans, update_item_status
+from app.schemas.study_plan import (
+	StudyPlanGenerateRequest,
+	StudyPlanItemRead,
+	StudyPlanItemSkillRead,
+	StudyPlanItemStatusUpdate,
+	StudyPlanRead,
+)
+from app.services.study_plan_service import (
+	generate_plan_for_job,
+	get_plan_for_job,
+	list_plans,
+	update_item_skill_status,
+	update_item_status,
+)
 
 router = APIRouter(prefix="/study-plans", tags=["study-plans"])
 
@@ -53,3 +65,15 @@ def update_study_plan_item_status_route(
 	"""Update the status of one study plan item."""
 
 	return update_item_status(db, str(current_user.email), item_id, payload.status)
+
+
+@router.patch("/item-skills/{item_skill_id}/status", response_model=StudyPlanItemSkillRead)
+def update_study_plan_item_skill_status_route(
+	item_skill_id: str,
+	payload: StudyPlanItemStatusUpdate,
+	db: Session = Depends(get_database),
+	current_user: User = Depends(get_current_user),
+) -> StudyPlanItemSkillRead:
+	"""Update the status of one module sub-skill (learning topic)."""
+
+	return update_item_skill_status(db, str(current_user.email), item_skill_id, payload.status)

--- a/backend/app/models/skill.py
+++ b/backend/app/models/skill.py
@@ -26,3 +26,4 @@ class Skill(Base):
 	user_skills = relationship("UserSkill", back_populates="skill")
 	job_skills = relationship("JobSkill", back_populates="skill")
 	study_items = relationship("StudyPlanItem", back_populates="skill")
+	study_item_skills = relationship("StudyPlanItemSkill", back_populates="skill")

--- a/backend/app/models/study_plan.py
+++ b/backend/app/models/study_plan.py
@@ -50,3 +50,37 @@ class StudyPlanItem(Base):
 
 	study_plan = relationship("StudyPlan", back_populates="items")
 	skill = relationship("Skill", back_populates="study_items")
+	subskills = relationship(
+		"StudyPlanItemSkill",
+		back_populates="study_plan_item",
+		cascade="all, delete-orphan",
+	)
+
+
+class StudyPlanItemSkill(Base):
+	"""Granular skill the user must learn to complete a study plan module."""
+
+	__tablename__ = "study_plan_item_skills"
+	__table_args__ = (
+		UniqueConstraint(
+			"study_plan_item_id",
+			"skill_id",
+			name="study_plan_item_skills_item_skill_key",
+		),
+	)
+
+	id = Column(String(36), primary_key=True, default=lambda: str(uuid4()))
+	study_plan_item_id = Column(
+		String(36),
+		ForeignKey("study_plan_items.id", ondelete="CASCADE"),
+		nullable=False,
+		index=True,
+	)
+	skill_id = Column(String(36), ForeignKey("skills.id", ondelete="RESTRICT"), nullable=False, index=True)
+	reason = Column(Text, nullable=True)
+	status = Column(SQLEnum(StudyPlanItemStatus), nullable=False, default=StudyPlanItemStatus.pending)
+	created_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+	updated_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now())
+
+	study_plan_item = relationship("StudyPlanItem", back_populates="subskills")
+	skill = relationship("Skill", back_populates="study_item_skills")

--- a/backend/app/repositories/job_skill_repository.py
+++ b/backend/app/repositories/job_skill_repository.py
@@ -113,6 +113,38 @@ def get_or_create_skill(db: Session, raw_name: str) -> Skill:
 	return skill
 
 
+SUBTOPIC_CATEGORY = "Subtopico"
+
+
+def resolve_or_create_subtopic_skill(db: Session, raw_name: str) -> Skill | None:
+	"""Resolve a learning topic to a catalog skill, creating it when needed.
+
+	Reuses an existing canonical skill when the name matches the catalog
+	(by name, slug or alias). Otherwise registers a new granular study topic
+	flagged as inactive and categorized as a subtopic, so it keeps the skill
+	pattern without polluting the user-facing catalog or the job matching.
+	"""
+
+	clean_name = (raw_name or "").strip()
+	if not clean_name:
+		return None
+
+	existing = resolve_catalog_skill(db, None, clean_name)
+	if existing:
+		return existing
+
+	skill = Skill(
+		canonical_name=clean_name,
+		slug=_normalize_skill_slug(clean_name),
+		category=SUBTOPIC_CATEGORY,
+		active=False,
+	)
+	db.add(skill)
+	db.commit()
+	db.refresh(skill)
+	return skill
+
+
 def resolve_catalog_skill(db: Session, skill_id: str | None = None, raw_name: str | None = None) -> Skill | None:
 	"""Resolve a catalog skill without creating new records."""
 

--- a/backend/app/repositories/job_skill_repository.py
+++ b/backend/app/repositories/job_skill_repository.py
@@ -116,26 +116,38 @@ def get_or_create_skill(db: Session, raw_name: str) -> Skill:
 SUBTOPIC_CATEGORY = "Subtopico"
 
 
-def resolve_or_create_subtopic_skill(db: Session, raw_name: str) -> Skill | None:
-	"""Resolve a learning topic to a catalog skill, creating it when needed.
+def _unique_subtopic_slug(db: Session, base_slug: str) -> str:
+	"""Return a slug guaranteed to be free in the skills table."""
 
-	Reuses an existing canonical skill when the name matches the catalog
-	(by name, slug or alias). Otherwise registers a new granular study topic
-	flagged as inactive and categorized as a subtopic, so it keeps the skill
-	pattern without polluting the user-facing catalog or the job matching.
+	import secrets
+
+	candidate = f"{base_slug}-sub"
+	while get_skill_by_slug(db, candidate) is not None:
+		candidate = f"{base_slug}-sub-{secrets.token_hex(3)}"
+	return candidate
+
+
+def resolve_or_create_subtopic_skill(db: Session, raw_name: str, module_name: str | None = None) -> Skill | None:
+	"""Register a granular learning topic as a catalog skill.
+
+	Each call creates a brand new inactive subtopic entry (category
+	"Subtopico"). Subtopics are study-scoped granular topics — reusing
+	canonical catalog skills would pollute the user-facing catalog and break
+	the per-module learning context, so we always materialize a new row.
 	"""
 
 	clean_name = (raw_name or "").strip()
 	if not clean_name:
 		return None
 
-	existing = resolve_catalog_skill(db, None, clean_name)
-	if existing:
-		return existing
+	canonical_name = clean_name
+	base_slug = _normalize_skill_slug(clean_name)
+	if module_name:
+		base_slug = f"{_normalize_skill_slug(module_name)}-{base_slug}"
 
 	skill = Skill(
-		canonical_name=clean_name,
-		slug=_normalize_skill_slug(clean_name),
+		canonical_name=canonical_name,
+		slug=_unique_subtopic_slug(db, base_slug),
 		category=SUBTOPIC_CATEGORY,
 		active=False,
 	)
@@ -145,12 +157,16 @@ def resolve_or_create_subtopic_skill(db: Session, raw_name: str) -> Skill | None
 	return skill
 
 
+def _is_subtopic(skill: Skill | None) -> bool:
+	return bool(skill) and getattr(skill, "category", None) == SUBTOPIC_CATEGORY
+
+
 def resolve_catalog_skill(db: Session, skill_id: str | None = None, raw_name: str | None = None) -> Skill | None:
-	"""Resolve a catalog skill without creating new records."""
+	"""Resolve a public catalog skill (subtopics are ignored on purpose)."""
 
 	if skill_id:
 		skill = get_skill_by_id(db, skill_id)
-		if skill:
+		if skill and not _is_subtopic(skill):
 			return skill
 
 	if not raw_name:
@@ -161,14 +177,18 @@ def resolve_catalog_skill(db: Session, skill_id: str | None = None, raw_name: st
 		return None
 
 	skill = get_skill_by_canonical_name(db, clean_name)
-	if skill:
+	if skill and not _is_subtopic(skill):
 		return skill
 
 	skill = get_skill_by_slug(db, _normalize_skill_slug(clean_name))
-	if skill:
+	if skill and not _is_subtopic(skill):
 		return skill
 
-	return get_skill_by_normalized_alias(db, normalize_skill_alias_key(clean_name))
+	skill = get_skill_by_normalized_alias(db, normalize_skill_alias_key(clean_name))
+	if skill and not _is_subtopic(skill):
+		return skill
+
+	return None
 
 def list_active_skills(db: Session) -> list[Skill]:
 	"""Return active catalog skills sorted by category and name."""

--- a/backend/app/repositories/study_plan_repository.py
+++ b/backend/app/repositories/study_plan_repository.py
@@ -4,7 +4,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session, joinedload, selectinload
 
 from app.models.enums import SkillLevel, SkillPriority, StudyPlanItemStatus, StudyPlanStatus
-from app.models.study_plan import StudyPlan, StudyPlanItem
+from app.models.study_plan import StudyPlan, StudyPlanItem, StudyPlanItemSkill
 
 
 def _map_level(level_name: str | None) -> SkillLevel | None:
@@ -53,6 +53,9 @@ def _map_item_status(status_name: str | None) -> StudyPlanItemStatus:
 def _plan_load_options():
 	return (
 		selectinload(StudyPlan.items).joinedload(StudyPlanItem.skill),
+		selectinload(StudyPlan.items)
+		.selectinload(StudyPlanItem.subskills)
+		.joinedload(StudyPlanItemSkill.skill),
 		joinedload(StudyPlan.job),
 	)
 
@@ -124,6 +127,21 @@ def create_or_replace_study_plan(
 			reason=item.get("reason"),
 			status=_map_item_status(item.get("status")),
 		)
+
+		seen_subskills: set[str] = set()
+		for subskill in item.get("subskills") or []:
+			subskill_id = subskill.get("skill_id")
+			if not subskill_id or str(subskill_id) in seen_subskills:
+				continue
+			study_item.subskills.append(
+				StudyPlanItemSkill(
+					skill_id=str(subskill_id),
+					reason=subskill.get("reason"),
+					status=_map_item_status(subskill.get("status")),
+				)
+			)
+			seen_subskills.add(str(subskill_id))
+
 		plan.items.append(study_item)
 
 	db.commit()
@@ -153,3 +171,43 @@ def update_study_plan_item_status(db: Session, item_id: str, status: str) -> Stu
 	db.commit()
 	db.refresh(item)
 	return item
+
+
+def get_item_skill_for_user(db: Session, user_id: str, item_skill_id: str) -> StudyPlanItemSkill | None:
+	"""Return a module sub-skill only when it belongs to the user."""
+
+	statement = (
+		select(StudyPlanItemSkill)
+		.join(StudyPlanItem, StudyPlanItem.id == StudyPlanItemSkill.study_plan_item_id)
+		.join(StudyPlan, StudyPlan.id == StudyPlanItem.study_plan_id)
+		.where(StudyPlanItemSkill.id == item_skill_id, StudyPlan.user_id == user_id)
+		.options(
+			joinedload(StudyPlanItemSkill.skill),
+			joinedload(StudyPlanItemSkill.study_plan_item).selectinload(StudyPlanItem.subskills),
+		)
+	)
+	return db.scalars(statement).unique().first()
+
+
+def set_item_skill_status(db: Session, item_skill: StudyPlanItemSkill, status: str) -> StudyPlanItemSkill:
+	"""Persist a sub-skill status and keep the parent module status in sync."""
+
+	item_skill.status = _map_item_status(status)
+	db.flush()
+
+	module = item_skill.study_plan_item
+	subskills = list(module.subskills)
+	all_completed = bool(subskills) and all(
+		sub.status == StudyPlanItemStatus.completed for sub in subskills
+	)
+
+	if all_completed:
+		module.status = StudyPlanItemStatus.completed
+	elif any(sub.status == StudyPlanItemStatus.completed for sub in subskills):
+		module.status = StudyPlanItemStatus.in_progress
+	else:
+		module.status = StudyPlanItemStatus.pending
+
+	db.commit()
+	db.refresh(item_skill)
+	return item_skill

--- a/backend/app/schemas/study_plan.py
+++ b/backend/app/schemas/study_plan.py
@@ -14,13 +14,28 @@ class StudyPlanGenerateRequest(BaseModel):
 
 
 class StudyPlanItemStatusUpdate(BaseModel):
-	"""Payload used to update a plan item status."""
+	"""Payload used to update a plan item or sub-skill status."""
 
 	status: str
 
 
+class StudyPlanItemSkillRead(BaseModel):
+	"""Sub-skill (learning topic) inside a study plan module."""
+
+	id: str
+	study_plan_item_id: str
+	skill_id: str
+	skill_name: str
+	reason: Optional[str] = None
+	status: str
+	created_at: datetime
+	updated_at: datetime
+
+	model_config = {"from_attributes": True}
+
+
 class StudyPlanItemRead(BaseModel):
-	"""Study plan item response."""
+	"""Study plan item (module) response."""
 
 	id: str
 	study_plan_id: str
@@ -33,6 +48,7 @@ class StudyPlanItemRead(BaseModel):
 	status: str
 	created_at: datetime
 	updated_at: datetime
+	subskills: list[StudyPlanItemSkillRead] = []
 
 	model_config = {"from_attributes": True}
 

--- a/backend/app/services/study_plan_service.py
+++ b/backend/app/services/study_plan_service.py
@@ -155,38 +155,77 @@ def _user_skills_for_ai(user_skills: list[object]) -> list[dict]:
 	return items
 
 
-def _resolve_subskills(db: Session, subskills: object, module_skill_id: str) -> list[dict]:
-	"""Resolve generated learning topics into catalog-backed sub-skill rows."""
+def _fallback_subskill_names(module_name: str) -> list[dict]:
+	"""Generic learning topics used when the model omits a module breakdown."""
 
-	resolved: list[dict] = []
-	seen: set[str] = set()
+	return [
+		{"name": f"Fundamentos de {module_name}", "reason": f"Dominar os conceitos basicos de {module_name}."},
+		{"name": f"Pratica guiada de {module_name}", "reason": f"Aplicar {module_name} em exercicios praticos."},
+		{"name": f"Projeto com {module_name}", "reason": f"Consolidar o aprendizado de {module_name} em um projeto."},
+	]
+
+
+def _resolve_subskills(db: Session, subskills: object, module_skill_id: str, module_name: str) -> list[dict]:
+	"""Resolve generated learning topics into freshly created subtopic skills."""
+
+	module_key = module_name.strip().lower()
+	candidates: list[dict] = []
+	seen_names: set[str] = {module_key} if module_key else set()
 	for subskill in subskills or []:
-		if not isinstance(subskill, dict):
-			continue
+		if isinstance(subskill, dict):
+			name = str(subskill.get("name") or subskill.get("skill_name") or "").strip()
+			reason = subskill.get("reason")
+		else:
+			name = str(subskill or "").strip()
+			reason = None
 
-		name = str(subskill.get("name") or "").strip()
 		if not name:
 			continue
 
-		catalog_skill = resolve_or_create_subtopic_skill(db, name)
+		key = name.lower()
+		if key in seen_names:
+			continue
+		seen_names.add(key)
+		candidates.append({"name": name, "reason": reason})
+
+	if not candidates:
+		candidates = _fallback_subskill_names(module_name)
+
+	resolved: list[dict] = []
+	for candidate in candidates[:5]:
+		catalog_skill = resolve_or_create_subtopic_skill(db, candidate["name"], module_name)
 		if not catalog_skill:
 			continue
-
-		skill_key = str(catalog_skill.id)
-		# A sub-skill must not duplicate the module skill nor a sibling topic.
-		if skill_key == module_skill_id or skill_key in seen:
+		if str(catalog_skill.id) == module_skill_id:
 			continue
-
 		resolved.append(
 			{
-				"skill_id": skill_key,
-				"reason": subskill.get("reason"),
+				"skill_id": str(catalog_skill.id),
+				"reason": candidate.get("reason"),
 				"status": "pending",
 			}
 		)
-		seen.add(skill_key)
 
 	return resolved
+
+
+def _filter_missing_job_skills(job_skills: list[object], user_skills: list[object]) -> list[object]:
+	"""Drop job skills the user already meets at or above the required level."""
+
+	user_level_by_skill_id = {
+		str(getattr(us, "skill_id")): _enum_value(getattr(us, "level", None))
+		for us in user_skills
+	}
+
+	missing: list[object] = []
+	for job_skill in job_skills:
+		skill_key = str(getattr(job_skill, "skill_id"))
+		required = _enum_value(getattr(job_skill, "required_level", SkillLevel.Basic))
+		current = user_level_by_skill_id.get(skill_key)
+		if _level_index(current) >= _level_index(required):
+			continue
+		missing.append(job_skill)
+	return missing
 
 
 def _normalize_generated_items(db: Session, generated_items: list[dict], job_skills: list[object], user_skills: list[object]) -> list[dict]:
@@ -210,12 +249,23 @@ def _normalize_generated_items(db: Session, generated_items: list[dict], job_ski
 		if not job_skill or skill_key in seen:
 			continue
 
+		# Always trust the user's recorded level over what the AI claims.
 		user_skill = user_skill_by_id.get(skill_key)
-		current_level = item.get("current_level") or _enum_value(getattr(user_skill, "level", None))
+		current_level = _enum_value(getattr(user_skill, "level", None))
 		target_level = item.get("target_level") or _enum_value(getattr(job_skill, "required_level", SkillLevel.Basic))
 
+		# Hard gate: user already meets/exceeds the required level.
+		required_level = _enum_value(getattr(job_skill, "required_level", SkillLevel.Basic))
+		if _level_index(current_level) >= _level_index(required_level):
+			continue
 		if _level_index(current_level) >= _level_index(target_level):
 			continue
+
+		module_name = (
+			str(getattr(getattr(job_skill, "skill", None), "canonical_name", ""))
+			or str(getattr(job_skill, "raw_name", ""))
+			or "esta habilidade"
+		)
 
 		normalized.append(
 			{
@@ -225,12 +275,38 @@ def _normalize_generated_items(db: Session, generated_items: list[dict], job_ski
 				"priority": item.get("priority") or _enum_value(getattr(job_skill, "priority", "desirable")),
 				"reason": item.get("reason"),
 				"status": "pending",
-				"subskills": _resolve_subskills(db, item.get("subskills"), skill_key),
+				"subskills": _resolve_subskills(db, item.get("subskills"), skill_key, module_name),
 			}
 		)
 		seen.add(skill_key)
 
 	return normalized
+
+
+def _items_from_missing_skills(db: Session, missing_job_skills: list[object]) -> list[dict]:
+	"""Backstop plan built directly from the gap, when the AI returns nothing."""
+
+	items: list[dict] = []
+	for job_skill in missing_job_skills:
+		skill_key = str(getattr(job_skill, "skill_id"))
+		module_name = (
+			str(getattr(getattr(job_skill, "skill", None), "canonical_name", ""))
+			or str(getattr(job_skill, "raw_name", ""))
+			or "esta habilidade"
+		)
+		target_level = _enum_value(getattr(job_skill, "required_level", SkillLevel.Basic))
+		items.append(
+			{
+				"skill_id": skill_key,
+				"current_level": None,
+				"target_level": target_level,
+				"priority": _enum_value(getattr(job_skill, "priority", "desirable")),
+				"reason": f"Desenvolver {module_name} para atender o nivel {target_level} exigido pela vaga.",
+				"status": "pending",
+				"subskills": _resolve_subskills(db, None, skill_key, module_name),
+			}
+		)
+	return items
 
 
 def generate_plan_for_job(db: Session, user_email: str, job_id: str, force_regenerate: bool = False) -> StudyPlanRead:
@@ -251,6 +327,14 @@ def generate_plan_for_job(db: Session, user_email: str, job_id: str, force_regen
 		)
 
 	user_skills = list_skills_by_user(db, user_id)
+
+	# Only ask the AI about the actual gap so it can't waste tokens on
+	# skills the user already meets at or above the required level.
+	missing_job_skills = _filter_missing_job_skills(job_skills, user_skills)
+	if not missing_job_skills:
+		plan = create_or_replace_study_plan(db, user_id, job_id, [], "completed")
+		return _plan_to_read(plan)
+
 	ai_payload = generate_study_plan(
 		job_context={
 			"job_id": str(job.id),
@@ -258,12 +342,18 @@ def generate_plan_for_job(db: Session, user_email: str, job_id: str, force_regen
 			"company": str(job.company_name),
 			"level": _enum_value(getattr(job, "level", None)),
 		},
-		job_skills=_job_skills_for_ai(job_skills),
+		job_skills=_job_skills_for_ai(missing_job_skills),
 		user_skills=_user_skills_for_ai(user_skills),
 	)
 
 	generated_items = ai_payload.get("items", []) if isinstance(ai_payload, dict) else []
-	items = _normalize_generated_items(db, generated_items, job_skills, user_skills)
+	items = _normalize_generated_items(db, generated_items, missing_job_skills, user_skills)
+
+	# Backstop: if the model returned nothing usable, build the plan
+	# directly from the gap so the user is never left without modules.
+	if not items:
+		items = _items_from_missing_skills(db, missing_job_skills)
+
 	plan_status = "active" if items else "completed"
 	plan = create_or_replace_study_plan(db, user_id, job_id, items, plan_status)
 	return _plan_to_read(plan)

--- a/backend/app/services/study_plan_service.py
+++ b/backend/app/services/study_plan_service.py
@@ -210,19 +210,19 @@ def _resolve_subskills(db: Session, subskills: object, module_skill_id: str, mod
 
 
 def _filter_missing_job_skills(job_skills: list[object], user_skills: list[object]) -> list[object]:
-	"""Drop job skills the user already meets at or above the required level."""
+	"""Keep only job skills the user has NOT added to their profile.
 
-	user_level_by_skill_id = {
-		str(getattr(us, "skill_id")): _enum_value(getattr(us, "level", None))
-		for us in user_skills
-	}
+	The study plan must contain exclusively the skills the user does not know
+	yet (i.e. never selected). Any job skill already present in the user's
+	profile, regardless of level, is ignored.
+	"""
+
+	known_skill_ids = {str(getattr(us, "skill_id")) for us in user_skills}
 
 	missing: list[object] = []
 	for job_skill in job_skills:
 		skill_key = str(getattr(job_skill, "skill_id"))
-		required = _enum_value(getattr(job_skill, "required_level", SkillLevel.Basic))
-		current = user_level_by_skill_id.get(skill_key)
-		if _level_index(current) >= _level_index(required):
+		if skill_key in known_skill_ids:
 			continue
 		missing.append(job_skill)
 	return missing
@@ -232,7 +232,7 @@ def _normalize_generated_items(db: Session, generated_items: list[dict], job_ski
 	"""Keep generated items valid for the selected job and current user levels."""
 
 	job_skill_by_id = {str(getattr(skill, "skill_id")): skill for skill in job_skills}
-	user_skill_by_id = {str(getattr(skill, "skill_id")): skill for skill in user_skills}
+	known_skill_ids = {str(getattr(us, "skill_id")) for us in user_skills}
 
 	normalized: list[dict] = []
 	seen: set[str] = set()
@@ -249,17 +249,12 @@ def _normalize_generated_items(db: Session, generated_items: list[dict], job_ski
 		if not job_skill or skill_key in seen:
 			continue
 
-		# Always trust the user's recorded level over what the AI claims.
-		user_skill = user_skill_by_id.get(skill_key)
-		current_level = _enum_value(getattr(user_skill, "level", None))
-		target_level = item.get("target_level") or _enum_value(getattr(job_skill, "required_level", SkillLevel.Basic))
+		# Hard gate: only skills the user does NOT know belong in the plan.
+		if skill_key in known_skill_ids:
+			continue
 
-		# Hard gate: user already meets/exceeds the required level.
-		required_level = _enum_value(getattr(job_skill, "required_level", SkillLevel.Basic))
-		if _level_index(current_level) >= _level_index(required_level):
-			continue
-		if _level_index(current_level) >= _level_index(target_level):
-			continue
+		current_level = None
+		target_level = item.get("target_level") or _enum_value(getattr(job_skill, "required_level", SkillLevel.Basic))
 
 		module_name = (
 			str(getattr(getattr(job_skill, "skill", None), "canonical_name", ""))

--- a/backend/app/services/study_plan_service.py
+++ b/backend/app/services/study_plan_service.py
@@ -4,19 +4,22 @@ from fastapi import HTTPException, status
 from sqlalchemy.orm import Session
 
 from ai_service.app.agents.plano_estudo import generate_study_plan
-from app.models.enums import SkillLevel
+from app.models.enums import SkillLevel, StudyPlanItemStatus
 from app.repositories.job_repository import get_job_by_id
-from app.repositories.job_skill_repository import list_job_skills_by_job
+from app.repositories.job_skill_repository import list_job_skills_by_job, resolve_or_create_subtopic_skill
 from app.repositories.study_plan_repository import (
 	create_or_replace_study_plan,
+	get_item_skill_for_user,
 	get_study_plan_by_user_and_job,
 	get_study_plan_item_for_user,
 	list_study_plans_by_user,
+	set_item_skill_status,
 	update_study_plan_item_status,
 )
 from app.repositories.user_repo import get_user_by_email
-from app.repositories.user_skill_repository import list_skills_by_user
-from app.schemas.study_plan import StudyPlanItemRead, StudyPlanRead
+from app.repositories.user_skill_repository import create_user_skill as create_user_skill_record, list_skills_by_user
+from app.schemas.study_plan import StudyPlanItemRead, StudyPlanItemSkillRead, StudyPlanRead
+from app.schemas.user_skill import UserSkillCreate
 
 
 LEVEL_ORDER = ["Beginner", "Basic", "Intermediate", "Advanced", "Specialist"]
@@ -56,10 +59,30 @@ def _resolve_job_for_user(db: Session, user_id: str, job_id: str):
 	return job
 
 
+def _item_skill_to_read(subskill: object) -> StudyPlanItemSkillRead:
+	"""Convert a module sub-skill into the public response schema."""
+
+	skill = getattr(subskill, "skill", None)
+	return StudyPlanItemSkillRead(
+		id=str(getattr(subskill, "id")),
+		study_plan_item_id=str(getattr(subskill, "study_plan_item_id")),
+		skill_id=str(getattr(subskill, "skill_id")),
+		skill_name=str(getattr(skill, "canonical_name", "")),
+		reason=getattr(subskill, "reason", None),
+		status=str(_enum_value(getattr(subskill, "status", "pending"))),
+		created_at=getattr(subskill, "created_at"),
+		updated_at=getattr(subskill, "updated_at"),
+	)
+
+
 def _item_to_read(item: object) -> StudyPlanItemRead:
 	"""Convert a study plan item into the public response schema."""
 
 	skill = getattr(item, "skill", None)
+	subskills = sorted(
+		list(getattr(item, "subskills", []) or []),
+		key=lambda sub: str(getattr(sub, "created_at", "")),
+	)
 	return StudyPlanItemRead(
 		id=str(getattr(item, "id")),
 		study_plan_id=str(getattr(item, "study_plan_id")),
@@ -72,6 +95,7 @@ def _item_to_read(item: object) -> StudyPlanItemRead:
 		status=str(_enum_value(getattr(item, "status", "pending"))),
 		created_at=getattr(item, "created_at"),
 		updated_at=getattr(item, "updated_at"),
+		subskills=[_item_skill_to_read(sub) for sub in subskills],
 	)
 
 
@@ -131,7 +155,41 @@ def _user_skills_for_ai(user_skills: list[object]) -> list[dict]:
 	return items
 
 
-def _normalize_generated_items(generated_items: list[dict], job_skills: list[object], user_skills: list[object]) -> list[dict]:
+def _resolve_subskills(db: Session, subskills: object, module_skill_id: str) -> list[dict]:
+	"""Resolve generated learning topics into catalog-backed sub-skill rows."""
+
+	resolved: list[dict] = []
+	seen: set[str] = set()
+	for subskill in subskills or []:
+		if not isinstance(subskill, dict):
+			continue
+
+		name = str(subskill.get("name") or "").strip()
+		if not name:
+			continue
+
+		catalog_skill = resolve_or_create_subtopic_skill(db, name)
+		if not catalog_skill:
+			continue
+
+		skill_key = str(catalog_skill.id)
+		# A sub-skill must not duplicate the module skill nor a sibling topic.
+		if skill_key == module_skill_id or skill_key in seen:
+			continue
+
+		resolved.append(
+			{
+				"skill_id": skill_key,
+				"reason": subskill.get("reason"),
+				"status": "pending",
+			}
+		)
+		seen.add(skill_key)
+
+	return resolved
+
+
+def _normalize_generated_items(db: Session, generated_items: list[dict], job_skills: list[object], user_skills: list[object]) -> list[dict]:
 	"""Keep generated items valid for the selected job and current user levels."""
 
 	job_skill_by_id = {str(getattr(skill, "skill_id")): skill for skill in job_skills}
@@ -167,6 +225,7 @@ def _normalize_generated_items(generated_items: list[dict], job_skills: list[obj
 				"priority": item.get("priority") or _enum_value(getattr(job_skill, "priority", "desirable")),
 				"reason": item.get("reason"),
 				"status": "pending",
+				"subskills": _resolve_subskills(db, item.get("subskills"), skill_key),
 			}
 		)
 		seen.add(skill_key)
@@ -204,7 +263,7 @@ def generate_plan_for_job(db: Session, user_email: str, job_id: str, force_regen
 	)
 
 	generated_items = ai_payload.get("items", []) if isinstance(ai_payload, dict) else []
-	items = _normalize_generated_items(generated_items, job_skills, user_skills)
+	items = _normalize_generated_items(db, generated_items, job_skills, user_skills)
 	plan_status = "active" if items else "completed"
 	plan = create_or_replace_study_plan(db, user_id, job_id, items, plan_status)
 	return _plan_to_read(plan)
@@ -240,5 +299,41 @@ def update_item_status(db: Session, user_email: str, item_id: str, item_status: 
 	if not updated:
 		raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Item do plano nao encontrado.")
 
+	if getattr(updated, "status", None) == StudyPlanItemStatus.completed:
+		_mark_module_skill_as_known(db, user_id, updated)
+
 	updated = get_study_plan_item_for_user(db, user_id, item_id)
 	return _item_to_read(updated)
+
+
+def _mark_module_skill_as_known(db: Session, user_id: str, module: object) -> None:
+	"""Persist the completed module skill into the user's known skills."""
+
+	skill_id = str(getattr(module, "skill_id", "") or "")
+	if not skill_id:
+		return
+
+	target_level = _enum_value(getattr(module, "target_level", None)) or SkillLevel.Basic.value
+	create_user_skill_record(db, user_id, skill_id, UserSkillCreate(skill_id=skill_id, level=target_level))
+
+
+def update_item_skill_status(db: Session, user_email: str, item_skill_id: str, item_status: str) -> StudyPlanItemSkillRead:
+	"""Update a module sub-skill status for the authenticated user.
+
+	When every sub-skill of the module is completed, the module skill is saved
+	as a known user skill so future job analyses score a higher compatibility.
+	"""
+
+	user_id = _resolve_user_id(db, user_email)
+	item_skill = get_item_skill_for_user(db, user_id, item_skill_id)
+	if not item_skill:
+		raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Item do plano nao encontrado.")
+
+	updated = set_item_skill_status(db, item_skill, item_status)
+
+	module = updated.study_plan_item
+	if getattr(module, "status", None) == StudyPlanItemStatus.completed:
+		_mark_module_skill_as_known(db, user_id, module)
+
+	refreshed = get_item_skill_for_user(db, user_id, item_skill_id)
+	return _item_skill_to_read(refreshed)

--- a/backend/prisma/migrations/20260608120000_add_study_plan_item_skills/migration.sql
+++ b/backend/prisma/migrations/20260608120000_add_study_plan_item_skills/migration.sql
@@ -1,0 +1,32 @@
+-- Add granular learning sub-skills inside each study plan module.
+
+BEGIN;
+
+-- CreateTable
+CREATE TABLE IF NOT EXISTS "study_plan_item_skills" (
+  "id" TEXT NOT NULL,
+  "study_plan_item_id" TEXT NOT NULL,
+  "skill_id" TEXT NOT NULL,
+  "reason" TEXT,
+  "status" "StudyPlanItemStatus" NOT NULL DEFAULT 'pending',
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "study_plan_item_skills_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "study_plan_item_skills_study_plan_item_id_idx" ON "study_plan_item_skills"("study_plan_item_id");
+CREATE INDEX IF NOT EXISTS "study_plan_item_skills_skill_id_idx" ON "study_plan_item_skills"("skill_id");
+CREATE UNIQUE INDEX IF NOT EXISTS "study_plan_item_skills_item_skill_key" ON "study_plan_item_skills"("study_plan_item_id", "skill_id");
+
+-- AddForeignKey
+ALTER TABLE "study_plan_item_skills" DROP CONSTRAINT IF EXISTS "study_plan_item_skills_study_plan_item_id_fkey";
+ALTER TABLE "study_plan_item_skills" ADD CONSTRAINT "study_plan_item_skills_study_plan_item_id_fkey"
+  FOREIGN KEY ("study_plan_item_id") REFERENCES "study_plan_items"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "study_plan_item_skills" DROP CONSTRAINT IF EXISTS "study_plan_item_skills_skill_id_fkey";
+ALTER TABLE "study_plan_item_skills" ADD CONSTRAINT "study_plan_item_skills_skill_id_fkey"
+  FOREIGN KEY ("skill_id") REFERENCES "skills"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+COMMIT;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -68,10 +68,11 @@ model Skill {
   active        Boolean         @default(true)
   createdAt     DateTime        @default(now()) @map("created_at")
   updatedAt     DateTime        @default(now()) @updatedAt @map("updated_at")
-  aliases       SkillAlias[]
-  userSkills    UserSkill[]
-  jobSkills     JobSkill[]
-  studyItems    StudyPlanItem[]
+  aliases        SkillAlias[]
+  userSkills     UserSkill[]
+  jobSkills      JobSkill[]
+  studyItems     StudyPlanItem[]
+  studyItemSkills StudyPlanItemSkill[]
 
   @@map("skills")
   @@index([category])
@@ -169,9 +170,27 @@ model StudyPlanItem {
   updatedAt     DateTime            @default(now()) @updatedAt @map("updated_at")
   studyPlan     StudyPlan           @relation(fields: [studyPlanId], references: [id], onDelete: Cascade)
   skill         Skill               @relation(fields: [skillId], references: [id], onDelete: Restrict)
+  subskills     StudyPlanItemSkill[]
 
   @@map("study_plan_items")
   @@index([studyPlanId])
   @@index([skillId])
   @@unique([studyPlanId, skillId])
+}
+
+model StudyPlanItemSkill {
+  id              String              @id @default(uuid())
+  studyPlanItemId String              @map("study_plan_item_id")
+  skillId         String              @map("skill_id")
+  reason          String?
+  status          StudyPlanItemStatus @default(pending)
+  createdAt       DateTime            @default(now()) @map("created_at")
+  updatedAt       DateTime            @default(now()) @updatedAt @map("updated_at")
+  studyPlanItem   StudyPlanItem       @relation(fields: [studyPlanItemId], references: [id], onDelete: Cascade)
+  skill           Skill               @relation(fields: [skillId], references: [id], onDelete: Restrict)
+
+  @@map("study_plan_item_skills")
+  @@index([studyPlanItemId])
+  @@index([skillId])
+  @@unique([studyPlanItemId, skillId])
 }

--- a/frontend/src/app/plano-estudos/page.tsx
+++ b/frontend/src/app/plano-estudos/page.tsx
@@ -20,11 +20,10 @@ export default function PlanoEstudosPage() {
     return () => window.clearTimeout(timer)
   }, [reloadPlans])
 
-  const totalTasks = plans.reduce((sum, plan) => sum + plan.tasks.length, 0)
-  const completedTasks = plans.reduce(
-    (sum, plan) => sum + plan.tasks.filter((task) => task.done).length,
-    0,
-  )
+  const totalModules = plans.length
+  const completedModules = plans.filter(
+    (plan) => plan.tasks.length > 0 && plan.tasks.every((task) => task.done),
+  ).length
   const selectedOpenPlanId = openPlanId === undefined ? plans[0]?.id ?? '' : openPlanId
 
   return (
@@ -45,7 +44,7 @@ export default function PlanoEstudosPage() {
                 <ShieldCheck size={20} />
               </div>
               <div className={styles.summaryMeta}>
-                <div className={styles.summaryBig}>{completedTasks}/{totalTasks}</div>
+                <div className={styles.summaryBig}>{completedModules}/{totalModules}</div>
                 <div className={styles.summarySmall}>Módulos concluídos</div>
               </div>
             </div>

--- a/frontend/src/contexts/StudyPlanContext.tsx
+++ b/frontend/src/contexts/StudyPlanContext.tsx
@@ -1,11 +1,14 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react'
 import { apiGet, apiPatch } from '../services/api'
 
+type TaskKind = 'subskill' | 'module'
+
 type StudyTask = {
   id: string
   title: string
   done: boolean
   doneAt?: string
+  kind: TaskKind
 }
 
 type SkillPlan = {
@@ -13,6 +16,13 @@ type SkillPlan = {
   name: string
   priority: 'alta' | 'media' | 'baixa'
   tasks: StudyTask[]
+}
+
+type StudyPlanItemSkillResponse = {
+  id: string
+  skill_name: string
+  reason?: string | null
+  status: 'pending' | 'in_progress' | 'completed' | 'skipped'
 }
 
 type StudyPlanItemResponse = {
@@ -23,6 +33,7 @@ type StudyPlanItemResponse = {
   priority: 'required' | 'desirable'
   reason?: string | null
   status: 'pending' | 'in_progress' | 'completed' | 'skipped'
+  subskills?: StudyPlanItemSkillResponse[]
 }
 
 type StudyPlanResponse = {
@@ -46,7 +57,15 @@ function mapPriority(priority: StudyPlanItemResponse['priority']): SkillPlan['pr
   return priority === 'required' ? 'alta' : 'media'
 }
 
-function buildTaskTitle(item: StudyPlanItemResponse): string {
+function buildSubskillTitle(subskill: StudyPlanItemSkillResponse): string {
+  if (subskill.reason?.trim()) {
+    return `${subskill.skill_name}: ${subskill.reason.trim()}`
+  }
+
+  return subskill.skill_name
+}
+
+function buildModuleTitle(item: StudyPlanItemResponse): string {
   if (item.reason?.trim()) {
     return item.reason.trim()
   }
@@ -55,19 +74,34 @@ function buildTaskTitle(item: StudyPlanItemResponse): string {
   return `Evoluir de ${current} para ${item.target_level}`
 }
 
+function mapItemTasks(item: StudyPlanItemResponse): StudyTask[] {
+  const subskills = item.subskills ?? []
+  if (subskills.length > 0) {
+    return subskills.map((subskill) => ({
+      id: subskill.id,
+      title: buildSubskillTitle(subskill),
+      done: subskill.status === 'completed',
+      kind: 'subskill' as const,
+    }))
+  }
+
+  return [
+    {
+      id: item.id,
+      title: buildModuleTitle(item),
+      done: item.status === 'completed',
+      kind: 'module' as const,
+    },
+  ]
+}
+
 function mapApiPlans(apiPlans: StudyPlanResponse[]): SkillPlan[] {
   return apiPlans.flatMap((plan) =>
     plan.items.map((item) => ({
       id: item.id,
       name: item.skill_name,
       priority: mapPriority(item.priority),
-      tasks: [
-        {
-          id: item.id,
-          title: buildTaskTitle(item),
-          done: item.status === 'completed',
-        },
-      ],
+      tasks: mapItemTasks(item),
     })),
   )
 }
@@ -143,11 +177,22 @@ export function StudyPlanProvider({ children }: { children: React.ReactNode }) {
       ),
     )
 
-    void apiPatch(`/study-plans/items/${taskId}/status`, {
+    const endpoint =
+      task.kind === 'subskill'
+        ? `/study-plans/item-skills/${taskId}/status`
+        : `/study-plans/items/${taskId}/status`
+
+    void apiPatch(endpoint, {
       status: nextDone ? 'completed' : 'pending',
-    }).catch(() => {
-      void reloadPlans()
     })
+      .then(() => {
+        // Completing every topic marks the module skill as known, so refresh
+        // to reflect the updated module/skill state coming from the backend.
+        void reloadPlans()
+      })
+      .catch(() => {
+        void reloadPlans()
+      })
   }, [plans, reloadPlans])
 
   const value = useMemo(


### PR DESCRIPTION
## Summary

This PR introduces a hierarchical structure to study plans by adding granular learning topics (subskills) within each study plan module. Users can now track progress on specific learning objectives that compose each skill, enabling more detailed progress tracking and better learning outcomes.

## Key Changes

### Backend - Data Model & Database
- Added `StudyPlanItemSkill` model to represent sub-skills within study plan items
- Created database migration to add `study_plan_item_skills` table with proper foreign keys and constraints
- Updated `Skill` model to include relationship to study item skills
- Added `StudyPlanItemSkillRead` schema for API responses

### Backend - Study Plan Generation
- Modified AI prompt to require subskills breakdown for each module (3-5 learning topics per skill)
- Added `_normalize_subskills()` and `_fallback_subskills()` functions to validate and generate subskills from AI responses
- Implemented `resolve_or_create_subtopic_skill()` to materialize learning topics as inactive catalog skills
- Updated `_normalize_generated_items()` to include subskill resolution in generated plans
- Added `_items_from_missing_skills()` backstop function to generate plans when AI returns nothing
- Improved skill gap filtering: only skills the user hasn't added to their profile are included in plans

### Backend - Study Plan Management
- Added `get_item_skill_for_user()` to retrieve subskills with proper authorization
- Added `set_item_skill_status()` to update subskill status and automatically sync parent module status
- Implemented `_mark_module_skill_as_known()` to persist completed modules as user skills
- Added `update_item_skill_status()` service function to handle subskill status updates
- New API endpoint: `PATCH /study-plans/item-skills/{item_skill_id}/status`

### Frontend - UI & State Management
- Updated `StudyPlanContext` to support two task kinds: 'module' and 'subskill'
- Modified task mapping to expand modules with subskills when available, or fall back to module-level tasks
- Updated progress tracking to count modules instead of individual tasks
- Enhanced task title generation with subskill-specific formatting
- Modified API calls to route subskill updates to the correct endpoint

### AI Service Improvements
- Increased max tokens from 1200 to 2400 to accommodate subskill generation
- Added early exit when job skills list is empty (no gap to fill)
- Updated fallback item generation to include subskills
- Improved normalization to handle both AI-generated and fallback subskills

## Notable Implementation Details

- **Subtopic Skills**: Subskills are created as inactive catalog skills with category "Subtopico" to keep them separate from public catalog skills and maintain per-module learning context
- **Automatic Module Completion**: When all subskills of a module are completed, the module is automatically marked as completed and the skill is added to the user's known skills
- **Skill Gap Filtering**: The system now filters out skills the user already knows before sending to the AI, reducing token usage and improving plan quality
- **Fallback Generation**: If the AI returns no usable items, the system generates a plan directly from the skill gap with generic subskill topics
- **Backward Compatibility**: Modules without subskills still work as single-task items in the UI

https://claude.ai/code/session_01WDFFMNf6c3ea31tx51EW4F