### PR TITLE
feat(study-plan): incluir apenas skills que o usuario nao conhece

### DIFF
--- a/ai_service/app/agents/plano_estudo.py
+++ b/ai_service/app/agents/plano_estudo.py
@@ -120,8 +120,8 @@ def _fallback_subskills(skill_name: str, target_level: str) -> list[dict]:
 
 
 def _fallback_items(job_skills: Iterable[dict], user_skills: Iterable[dict]) -> list[dict]:
-	user_levels = {
-		str(skill.get("skill_id")): _normalize_level(skill.get("level"))
+	known_skill_ids = {
+		str(skill.get("skill_id"))
 		for skill in user_skills
 		if isinstance(skill, dict) and skill.get("skill_id")
 	}
@@ -135,10 +135,12 @@ def _fallback_items(job_skills: Iterable[dict], user_skills: Iterable[dict]) -> 
 		if not skill_id:
 			continue
 
-		target_level = _normalize_level(skill.get("required_level"), "Basic")
-		current_level = user_levels.get(str(skill_id))
-		if _level_index(current_level) >= _level_index(target_level):
+		# Only skills the user does not know belong in the plan.
+		if str(skill_id) in known_skill_ids:
 			continue
+
+		target_level = _normalize_level(skill.get("required_level"), "Basic")
+		current_level = None
 
 		skill_name = skill.get("skill_name") or skill.get("raw_name") or "esta habilidade"
 		items.append(
@@ -170,8 +172,8 @@ def _normalize_ai_items(parsed: dict, job_skills: list[dict], user_skills: list[
 		for skill in job_skills
 		if isinstance(skill, dict) and skill.get("skill_id")
 	}
-	user_levels = {
-		str(skill.get("skill_id")): _normalize_level(skill.get("level"))
+	known_skill_ids = {
+		str(skill.get("skill_id"))
 		for skill in user_skills
 		if isinstance(skill, dict) and skill.get("skill_id")
 	}
@@ -191,14 +193,12 @@ def _normalize_ai_items(parsed: dict, job_skills: list[dict], user_skills: list[
 		if not job_skill or skill_key in seen:
 			continue
 
-		# Trust the user-provided level over whatever the model guesses.
-		current_level = user_levels.get(skill_key)
+		# Only skills the user does not know belong in the plan.
+		if skill_key in known_skill_ids:
+			continue
+
+		current_level = None
 		target_level = _normalize_level(item.get("target_level"), _normalize_level(job_skill.get("required_level"), "Basic"))
-		required_level = _normalize_level(job_skill.get("required_level"), "Basic")
-		if _level_index(current_level) >= _level_index(required_level):
-			continue
-		if _level_index(current_level) >= _level_index(target_level):
-			continue
 
 		skill_name = job_skill.get("skill_name") or job_skill.get("raw_name") or "esta habilidade"
 		reason = str(item.get("reason") or "").strip()

--- a/ai_service/app/prompts/plano_prompt.txt
+++ b/ai_service/app/prompts/plano_prompt.txt
@@ -4,10 +4,10 @@ requires that the user is still missing. Inside each module you must break
 that skill down into the concrete sub-skills (learning topics) the user must
 learn so the module skill can be considered mastered.
 
-The "Job skills" payload below ONLY contains the skills the user does NOT
-already meet. The "User skills" payload is provided as background only — never
-emit a module for any skill the user already has at or above the required
-level. If "Job skills" is empty, return {"items":[]}.
+The "Job skills" payload below ONLY contains skills the user does NOT have in
+their profile yet. The "User skills" payload is provided as background only —
+never emit a module for any skill already present in the user's profile,
+regardless of level. If "Job skills" is empty, return {"items":[]}.
 
 Return only valid JSON in this exact shape:
 {"items":[{"skill_id":"string","current_level":"Beginner|Basic|Intermediate|Advanced|Specialist|null","target_level":"Basic|Intermediate|Advanced|Specialist","priority":"required|desirable","reason":"string","subskills":[{"name":"string","reason":"string"}]}]}

--- a/backend/app/services/study_plan_service.py
+++ b/backend/app/services/study_plan_service.py
@@ -210,19 +210,19 @@ def _resolve_subskills(db: Session, subskills: object, module_skill_id: str, mod
 
 
 def _filter_missing_job_skills(job_skills: list[object], user_skills: list[object]) -> list[object]:
-	"""Drop job skills the user already meets at or above the required level."""
+	"""Keep only job skills the user has NOT added to their profile.
 
-	user_level_by_skill_id = {
-		str(getattr(us, "skill_id")): _enum_value(getattr(us, "level", None))
-		for us in user_skills
-	}
+	The study plan must contain exclusively the skills the user does not know
+	yet (i.e. never selected). Any job skill already present in the user's
+	profile, regardless of level, is ignored.
+	"""
+
+	known_skill_ids = {str(getattr(us, "skill_id")) for us in user_skills}
 
 	missing: list[object] = []
 	for job_skill in job_skills:
 		skill_key = str(getattr(job_skill, "skill_id"))
-		required = _enum_value(getattr(job_skill, "required_level", SkillLevel.Basic))
-		current = user_level_by_skill_id.get(skill_key)
-		if _level_index(current) >= _level_index(required):
+		if skill_key in known_skill_ids:
 			continue
 		missing.append(job_skill)
 	return missing
@@ -232,7 +232,7 @@ def _normalize_generated_items(db: Session, generated_items: list[dict], job_ski
 	"""Keep generated items valid for the selected job and current user levels."""
 
 	job_skill_by_id = {str(getattr(skill, "skill_id")): skill for skill in job_skills}
-	user_skill_by_id = {str(getattr(skill, "skill_id")): skill for skill in user_skills}
+	known_skill_ids = {str(getattr(us, "skill_id")) for us in user_skills}
 
 	normalized: list[dict] = []
 	seen: set[str] = set()
@@ -249,17 +249,12 @@ def _normalize_generated_items(db: Session, generated_items: list[dict], job_ski
 		if not job_skill or skill_key in seen:
 			continue
 
-		# Always trust the user's recorded level over what the AI claims.
-		user_skill = user_skill_by_id.get(skill_key)
-		current_level = _enum_value(getattr(user_skill, "level", None))
-		target_level = item.get("target_level") or _enum_value(getattr(job_skill, "required_level", SkillLevel.Basic))
+		# Hard gate: only skills the user does NOT know belong in the plan.
+		if skill_key in known_skill_ids:
+			continue
 
-		# Hard gate: user already meets/exceeds the required level.
-		required_level = _enum_value(getattr(job_skill, "required_level", SkillLevel.Basic))
-		if _level_index(current_level) >= _level_index(required_level):
-			continue
-		if _level_index(current_level) >= _level_index(target_level):
-			continue
+		current_level = None
+		target_level = item.get("target_level") or _enum_value(getattr(job_skill, "required_level", SkillLevel.Basic))
 
 		module_name = (
 			str(getattr(getattr(job_skill, "skill", None), "canonical_name", ""))


### PR DESCRIPTION
O plano de estudos agora contem exclusivamente as habilidades que o usuario NAO selecionou no perfil (nao conhece). Qualquer skill ja presente em user_skills, independente do nivel, e ignorada.

- _filter_missing_job_skills passa a excluir por presenca no perfil (antes comparava nivel), no service e no agent de IA (defense-in-depth)
- prompt atualizado: a IA so recebe o gap real e nunca emite modulo para skill ja presente no perfil
- modulos em study_plan_items continuam ligados a uma skill canonica do catalogo (FK skills.id, como user_skills), sem criar rows duplicadas