### PR TITLE
feat(study-plan): separar planos por vaga com nome, cards e sync entr…

### DIFF
--- a/backend/app/api/routes/study_plan.py
+++ b/backend/app/api/routes/study_plan.py
@@ -1,6 +1,6 @@
 """Study plan routes."""
 
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, Response, status
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_current_user, get_database
@@ -11,11 +11,14 @@ from app.schemas.study_plan import (
 	StudyPlanItemSkillRead,
 	StudyPlanItemStatusUpdate,
 	StudyPlanRead,
+	StudyPlanRenameRequest,
 )
 from app.services.study_plan_service import (
+	delete_plan,
 	generate_plan_for_job,
 	get_plan_for_job,
 	list_plans,
+	rename_plan,
 	update_item_skill_status,
 	update_item_status,
 )
@@ -31,7 +34,13 @@ def generate_study_plan_route(
 ) -> StudyPlanRead:
 	"""Generate and persist a study plan for a job."""
 
-	return generate_plan_for_job(db, str(current_user.email), payload.job_id, payload.force_regenerate)
+	return generate_plan_for_job(
+		db,
+		str(current_user.email),
+		payload.job_id,
+		payload.force_regenerate,
+		payload.title,
+	)
 
 
 @router.get("", response_model=list[StudyPlanRead])
@@ -53,6 +62,30 @@ def get_study_plan_for_job_route(
 	"""Return a study plan generated for a job."""
 
 	return get_plan_for_job(db, str(current_user.email), job_id)
+
+
+@router.patch("/{plan_id}", response_model=StudyPlanRead)
+def rename_study_plan_route(
+	plan_id: str,
+	payload: StudyPlanRenameRequest,
+	db: Session = Depends(get_database),
+	current_user: User = Depends(get_current_user),
+) -> StudyPlanRead:
+	"""Rename a study plan."""
+
+	return rename_plan(db, str(current_user.email), plan_id, payload.title)
+
+
+@router.delete("/{plan_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_study_plan_route(
+	plan_id: str,
+	db: Session = Depends(get_database),
+	current_user: User = Depends(get_current_user),
+) -> Response:
+	"""Delete a study plan owned by the user."""
+
+	delete_plan(db, str(current_user.email), plan_id)
+	return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.patch("/items/{item_id}/status", response_model=StudyPlanItemRead)

--- a/backend/app/models/study_plan.py
+++ b/backend/app/models/study_plan.py
@@ -20,6 +20,7 @@ class StudyPlan(Base):
 	id = Column(String(36), primary_key=True, default=lambda: str(uuid4()))
 	user_id = Column(String(36), ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
 	job_id = Column(String(36), ForeignKey("jobs.id", ondelete="CASCADE"), nullable=False, index=True)
+	title = Column(String(200), nullable=True)
 	status = Column(SQLEnum(StudyPlanStatus), nullable=False, default=StudyPlanStatus.draft)
 	created_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
 	updated_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now())

--- a/backend/app/repositories/study_plan_repository.py
+++ b/backend/app/repositories/study_plan_repository.py
@@ -100,6 +100,7 @@ def create_or_replace_study_plan(
 	job_id: str,
 	items: list[dict],
 	status: str = "active",
+	title: str | None = None,
 ) -> StudyPlan:
 	"""Create a plan or replace the items of the existing user/job plan."""
 
@@ -107,10 +108,13 @@ def create_or_replace_study_plan(
 	if plan:
 		plan.items.clear()
 		plan.status = _map_plan_status(status)
+		if title is not None:
+			plan.title = title
 	else:
 		plan = StudyPlan(
 			user_id=user_id,
 			job_id=job_id,
+			title=title,
 			status=_map_plan_status(status),
 		)
 		db.add(plan)
@@ -187,6 +191,47 @@ def get_item_skill_for_user(db: Session, user_id: str, item_skill_id: str) -> St
 		)
 	)
 	return db.scalars(statement).unique().first()
+
+
+def rename_study_plan(db: Session, plan: StudyPlan, title: str) -> StudyPlan:
+	"""Update the user-facing title of a study plan."""
+
+	plan.title = title
+	db.commit()
+	db.refresh(plan)
+	return plan
+
+
+def delete_study_plan(db: Session, plan: StudyPlan) -> None:
+	"""Remove a study plan and its cascaded children."""
+
+	db.delete(plan)
+	db.commit()
+
+
+def list_user_items_for_skill(
+	db: Session, user_id: str, skill_id: str, exclude_item_id: str | None = None
+) -> list[StudyPlanItem]:
+	"""Return every plan item for a user that targets the given skill."""
+
+	statement = (
+		select(StudyPlanItem)
+		.join(StudyPlan, StudyPlan.id == StudyPlanItem.study_plan_id)
+		.where(StudyPlan.user_id == user_id, StudyPlanItem.skill_id == skill_id)
+		.options(selectinload(StudyPlanItem.subskills))
+	)
+	if exclude_item_id:
+		statement = statement.where(StudyPlanItem.id != exclude_item_id)
+	return list(db.scalars(statement).unique().all())
+
+
+def mark_item_completed(db: Session, item: StudyPlanItem) -> None:
+	"""Mark a plan item and all of its sub-skills as completed."""
+
+	item.status = StudyPlanItemStatus.completed
+	for subskill in item.subskills:
+		subskill.status = StudyPlanItemStatus.completed
+	db.flush()
 
 
 def set_item_skill_status(db: Session, item_skill: StudyPlanItemSkill, status: str) -> StudyPlanItemSkill:

--- a/backend/app/schemas/study_plan.py
+++ b/backend/app/schemas/study_plan.py
@@ -10,7 +10,14 @@ class StudyPlanGenerateRequest(BaseModel):
 	"""Payload used to generate a study plan for a job."""
 
 	job_id: str
+	title: Optional[str] = None
 	force_regenerate: bool = False
+
+
+class StudyPlanRenameRequest(BaseModel):
+	"""Payload used to rename a study plan."""
+
+	title: str
 
 
 class StudyPlanItemStatusUpdate(BaseModel):
@@ -59,6 +66,9 @@ class StudyPlanRead(BaseModel):
 	id: str
 	user_id: str
 	job_id: str
+	title: str
+	job_title: Optional[str] = None
+	company_name: Optional[str] = None
 	status: str
 	created_at: datetime
 	updated_at: datetime

--- a/backend/app/services/study_plan_service.py
+++ b/backend/app/services/study_plan_service.py
@@ -9,10 +9,15 @@ from app.repositories.job_repository import get_job_by_id
 from app.repositories.job_skill_repository import list_job_skills_by_job, resolve_or_create_subtopic_skill
 from app.repositories.study_plan_repository import (
 	create_or_replace_study_plan,
+	delete_study_plan,
 	get_item_skill_for_user,
+	get_study_plan_by_id_for_user,
 	get_study_plan_by_user_and_job,
 	get_study_plan_item_for_user,
 	list_study_plans_by_user,
+	list_user_items_for_skill,
+	mark_item_completed,
+	rename_study_plan,
 	set_item_skill_status,
 	update_study_plan_item_status,
 )
@@ -99,6 +104,18 @@ def _item_to_read(item: object) -> StudyPlanItemRead:
 	)
 
 
+def _default_plan_title(job: object) -> str:
+	"""Build the default plan title shown to the user."""
+
+	job_title = str(getattr(job, "job_title", "") or "").strip()
+	company = str(getattr(job, "company_name", "") or "").strip()
+	if job_title and company:
+		return f"Plano para {job_title} - {company}"
+	if job_title:
+		return f"Plano para {job_title}"
+	return "Plano de estudos"
+
+
 def _plan_to_read(plan: object) -> StudyPlanRead:
 	"""Convert a study plan into the public response schema."""
 
@@ -110,10 +127,16 @@ def _plan_to_read(plan: object) -> StudyPlanRead:
 		)
 	)
 
+	job = getattr(plan, "job", None)
+	title = str(getattr(plan, "title", "") or "").strip() or _default_plan_title(job)
+
 	return StudyPlanRead(
 		id=str(getattr(plan, "id")),
 		user_id=str(getattr(plan, "user_id")),
 		job_id=str(getattr(plan, "job_id")),
+		title=title,
+		job_title=str(getattr(job, "job_title", "") or "") or None,
+		company_name=str(getattr(job, "company_name", "") or "") or None,
 		status=str(_enum_value(getattr(plan, "status", "active"))),
 		created_at=getattr(plan, "created_at"),
 		updated_at=getattr(plan, "updated_at"),
@@ -304,14 +327,26 @@ def _items_from_missing_skills(db: Session, missing_job_skills: list[object]) ->
 	return items
 
 
-def generate_plan_for_job(db: Session, user_email: str, job_id: str, force_regenerate: bool = False) -> StudyPlanRead:
+def generate_plan_for_job(
+	db: Session,
+	user_email: str,
+	job_id: str,
+	force_regenerate: bool = False,
+	title: str | None = None,
+) -> StudyPlanRead:
 	"""Generate and persist a study plan for a job."""
 
 	user_id = _resolve_user_id(db, user_email)
 	job = _resolve_job_for_user(db, user_id, job_id)
 
+	plan_title = (title or "").strip() or _default_plan_title(job)
+
 	existing_plan = get_study_plan_by_user_and_job(db, user_id, job_id)
 	if existing_plan and not force_regenerate:
+		# Backfill the title for legacy plans that were generated before
+		# user-facing names existed.
+		if not getattr(existing_plan, "title", None):
+			rename_study_plan(db, existing_plan, plan_title)
 		return _plan_to_read(existing_plan)
 
 	job_skills = list_job_skills_by_job(db, job_id)
@@ -327,7 +362,7 @@ def generate_plan_for_job(db: Session, user_email: str, job_id: str, force_regen
 	# skills the user already meets at or above the required level.
 	missing_job_skills = _filter_missing_job_skills(job_skills, user_skills)
 	if not missing_job_skills:
-		plan = create_or_replace_study_plan(db, user_id, job_id, [], "completed")
+		plan = create_or_replace_study_plan(db, user_id, job_id, [], "completed", title=plan_title)
 		return _plan_to_read(plan)
 
 	ai_payload = generate_study_plan(
@@ -350,7 +385,7 @@ def generate_plan_for_job(db: Session, user_email: str, job_id: str, force_regen
 		items = _items_from_missing_skills(db, missing_job_skills)
 
 	plan_status = "active" if items else "completed"
-	plan = create_or_replace_study_plan(db, user_id, job_id, items, plan_status)
+	plan = create_or_replace_study_plan(db, user_id, job_id, items, plan_status, title=plan_title)
 	return _plan_to_read(plan)
 
 
@@ -372,6 +407,57 @@ def get_plan_for_job(db: Session, user_email: str, job_id: str) -> StudyPlanRead
 	return _plan_to_read(plan)
 
 
+def rename_plan(db: Session, user_email: str, plan_id: str, title: str) -> StudyPlanRead:
+	"""Rename a study plan owned by the authenticated user."""
+
+	clean_title = (title or "").strip()
+	if not clean_title:
+		raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Informe um nome para o plano.")
+	if len(clean_title) > 200:
+		raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="O nome do plano deve ter ate 200 caracteres.")
+
+	user_id = _resolve_user_id(db, user_email)
+	plan = get_study_plan_by_id_for_user(db, user_id, plan_id)
+	if not plan:
+		raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Plano de estudos nao encontrado.")
+
+	rename_study_plan(db, plan, clean_title)
+	refreshed = get_study_plan_by_id_for_user(db, user_id, plan_id)
+	return _plan_to_read(refreshed)
+
+
+def delete_plan(db: Session, user_email: str, plan_id: str) -> None:
+	"""Delete a study plan owned by the authenticated user."""
+
+	user_id = _resolve_user_id(db, user_email)
+	plan = get_study_plan_by_id_for_user(db, user_id, plan_id)
+	if not plan:
+		raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Plano de estudos nao encontrado.")
+	delete_study_plan(db, plan)
+
+
+def _sync_skill_completion_across_plans(db: Session, user_id: str, completed_item: object) -> None:
+	"""Mark the same skill as completed in every other plan of this user.
+
+	Rationale: once the user finishes a module (the skill is added to the
+	user's profile), seeing it as pending in another plan would be confusing.
+	"""
+
+	skill_id = str(getattr(completed_item, "skill_id", "") or "")
+	if not skill_id:
+		return
+
+	siblings = list_user_items_for_skill(db, user_id, skill_id, exclude_item_id=str(completed_item.id))
+	if not siblings:
+		return
+
+	for sibling in siblings:
+		if sibling.status == StudyPlanItemStatus.completed:
+			continue
+		mark_item_completed(db, sibling)
+	db.commit()
+
+
 def update_item_status(db: Session, user_email: str, item_id: str, item_status: str) -> StudyPlanItemRead:
 	"""Update an item status for the authenticated user."""
 
@@ -386,6 +472,7 @@ def update_item_status(db: Session, user_email: str, item_id: str, item_status: 
 
 	if getattr(updated, "status", None) == StudyPlanItemStatus.completed:
 		_mark_module_skill_as_known(db, user_id, updated)
+		_sync_skill_completion_across_plans(db, user_id, updated)
 
 	updated = get_study_plan_item_for_user(db, user_id, item_id)
 	return _item_to_read(updated)
@@ -419,6 +506,7 @@ def update_item_skill_status(db: Session, user_email: str, item_skill_id: str, i
 	module = updated.study_plan_item
 	if getattr(module, "status", None) == StudyPlanItemStatus.completed:
 		_mark_module_skill_as_known(db, user_id, module)
+		_sync_skill_completion_across_plans(db, user_id, module)
 
 	refreshed = get_item_skill_for_user(db, user_id, item_skill_id)
 	return _item_skill_to_read(refreshed)

--- a/backend/prisma/migrations/20260609120000_add_study_plan_title/migration.sql
+++ b/backend/prisma/migrations/20260609120000_add_study_plan_title/migration.sql
@@ -1,0 +1,8 @@
+-- Add a user-facing title to study plans so the user can identify each plan
+-- (default named "Plano para {Cargo} - {Empresa}" when generated).
+
+BEGIN;
+
+ALTER TABLE "study_plans" ADD COLUMN IF NOT EXISTS "title" VARCHAR(200);
+
+COMMIT;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -144,6 +144,7 @@ model StudyPlan {
   id        String              @id @default(uuid())
   userId    String              @map("user_id")
   jobId     String              @map("job_id")
+  title     String?
   status    StudyPlanStatus     @default(draft)
   createdAt DateTime            @default(now()) @map("created_at")
   updatedAt DateTime            @default(now()) @updatedAt @map("updated_at")

--- a/frontend/src/app/plano-estudos/page.tsx
+++ b/frontend/src/app/plano-estudos/page.tsx
@@ -1,6 +1,7 @@
-import { BookOpen, ShieldCheck } from 'lucide-react'
-import { useEffect, useState } from 'react'
-import { useStudyPlan } from '../../contexts/StudyPlanContext'
+import { ArrowLeft, BookOpen, Briefcase, Calendar, Pencil, ShieldCheck, Trash2 } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+import { useSearchParams } from 'react-router-dom'
+import { useStudyPlan, type StudyPlan } from '../../contexts/StudyPlanContext'
 
 import PageContainer from '../../components/PageContainer/PageContainer'
 import PageHeader from '../../components/PageHeader/PageHeader'
@@ -8,9 +9,32 @@ import PageHeader from '../../components/PageHeader/PageHeader'
 import LoadingState from '../../components/LoadingState/LoadingState'
 import styles from './plano-estudos.module.css'
 
+function formatDate(value: string): string {
+  try {
+    return new Date(value).toLocaleDateString('pt-BR', {
+      day: '2-digit',
+      month: 'short',
+      year: 'numeric',
+    })
+  } catch {
+    return value
+  }
+}
+
+function planStats(plan: StudyPlan) {
+  const totalModules = plan.modules.length
+  const completedModules = plan.modules.filter(
+    (mod) => mod.tasks.length > 0 && mod.tasks.every((task) => task.done),
+  ).length
+  const progress = totalModules ? Math.round((completedModules / totalModules) * 100) : 0
+  return { totalModules, completedModules, progress }
+}
+
 export default function PlanoEstudosPage() {
-  const { plans, isLoading, error, reloadPlans, toggleTask } = useStudyPlan()
-  const [openPlanId, setOpenPlanId] = useState<string | undefined>(undefined)
+  const { plans, isLoading, error, reloadPlans, toggleTask, renamePlan, deletePlan } = useStudyPlan()
+  const [selectedPlanId, setSelectedPlanId] = useState<string | null>(null)
+  const [openModuleId, setOpenModuleId] = useState<string | undefined>(undefined)
+  const [searchParams, setSearchParams] = useSearchParams()
 
   useEffect(() => {
     const timer = window.setTimeout(() => {
@@ -20,11 +44,43 @@ export default function PlanoEstudosPage() {
     return () => window.clearTimeout(timer)
   }, [reloadPlans])
 
-  const totalModules = plans.length
-  const completedModules = plans.filter(
-    (plan) => plan.tasks.length > 0 && plan.tasks.every((task) => task.done),
-  ).length
-  const selectedOpenPlanId = openPlanId === undefined ? plans[0]?.id ?? '' : openPlanId
+  // Auto-open the plan that matches the ?jobId coming from "Gerar plano".
+  useEffect(() => {
+    const jobId = searchParams.get('jobId')
+    if (!jobId || plans.length === 0) return
+    const match = plans.find((p) => p.jobId === jobId)
+    if (match) {
+      setSelectedPlanId(match.id)
+      searchParams.delete('jobId')
+      setSearchParams(searchParams, { replace: true })
+    }
+  }, [plans, searchParams, setSearchParams])
+
+  const selectedPlan = useMemo(
+    () => plans.find((plan) => plan.id === selectedPlanId) ?? null,
+    [plans, selectedPlanId],
+  )
+
+  if (selectedPlan) {
+    return (
+      <PlanDetailView
+        plan={selectedPlan}
+        openModuleId={openModuleId}
+        onOpenModule={setOpenModuleId}
+        onBack={() => {
+          setSelectedPlanId(null)
+          setOpenModuleId(undefined)
+        }}
+        onToggleTask={toggleTask}
+      />
+    )
+  }
+
+  const totalPlans = plans.length
+  const completedPlans = plans.filter((plan) => {
+    const { totalModules, completedModules } = planStats(plan)
+    return totalModules > 0 && completedModules === totalModules
+  }).length
 
   return (
     <div className={styles.content}>
@@ -32,11 +88,196 @@ export default function PlanoEstudosPage() {
         <div className={styles.pageStack}>
           <PageHeader
             title="Plano de Estudos"
-            description="Plano personalizado baseado nas vagas que você analisou"
+            description="Cada vaga analisada gera um plano separado. Selecione um para ver os módulos."
           />
 
-          {isLoading ? <LoadingState message="Carregando plano de estudos" /> : null}
+          {isLoading ? <LoadingState message="Carregando planos de estudo" /> : null}
           {error ? <div className={styles.pageError}>{error}</div> : null}
+
+          <section className={styles.summaryCards} aria-label="Resumo">
+            <div className={`${styles.summaryCard} ${styles.cardGlass}`}>
+              <div className={styles.summaryIconBox} aria-hidden="true">
+                <BookOpen size={20} />
+              </div>
+              <div className={styles.summaryMeta}>
+                <div className={styles.summaryBig}>{totalPlans}</div>
+                <div className={styles.summarySmall}>Planos gerados</div>
+              </div>
+            </div>
+
+            <div className={`${styles.summaryCard} ${styles.cardGlass}`}>
+              <div className={styles.summaryIconBox} aria-hidden="true">
+                <ShieldCheck size={20} />
+              </div>
+              <div className={styles.summaryMeta}>
+                <div className={styles.summaryBig}>{completedPlans}/{totalPlans}</div>
+                <div className={styles.summarySmall}>Planos concluídos</div>
+              </div>
+            </div>
+          </section>
+
+          {!isLoading && plans.length === 0 ? (
+            <section className={styles.emptyState} aria-label="Plano vazio">
+              Nenhum plano de estudos gerado ainda. Analise uma vaga para gerar o primeiro.
+            </section>
+          ) : null}
+
+          {plans.length > 0 ? (
+            <section className={styles.planGrid} aria-label="Planos de estudo">
+              {plans.map((plan) => (
+                <PlanCard
+                  key={plan.id}
+                  plan={plan}
+                  onOpen={() => setSelectedPlanId(plan.id)}
+                  onRename={async (title) => {
+                    await renamePlan(plan.id, title)
+                  }}
+                  onDelete={async () => {
+                    await deletePlan(plan.id)
+                  }}
+                />
+              ))}
+            </section>
+          ) : null}
+        </div>
+      </PageContainer>
+    </div>
+  )
+}
+
+type PlanCardProps = {
+  plan: StudyPlan
+  onOpen: () => void
+  onRename: (title: string) => Promise<void>
+  onDelete: () => Promise<void>
+}
+
+function PlanCard({ plan, onOpen, onRename, onDelete }: PlanCardProps) {
+  const { totalModules, completedModules, progress } = planStats(plan)
+  const [isBusy, setIsBusy] = useState(false)
+
+  const jobLabel = [plan.jobTitle, plan.companyName].filter(Boolean).join(' · ')
+
+  const handleRename = async (event: React.MouseEvent) => {
+    event.stopPropagation()
+    const next = window.prompt('Novo nome do plano:', plan.title)
+    if (!next || next.trim() === plan.title) return
+    setIsBusy(true)
+    try {
+      await onRename(next.trim())
+    } finally {
+      setIsBusy(false)
+    }
+  }
+
+  const handleDelete = async (event: React.MouseEvent) => {
+    event.stopPropagation()
+    const ok = window.confirm(`Excluir o plano "${plan.title}"? Esta ação não pode ser desfeita.`)
+    if (!ok) return
+    setIsBusy(true)
+    try {
+      await onDelete()
+    } finally {
+      setIsBusy(false)
+    }
+  }
+
+  return (
+    <article
+      className={styles.planCard}
+      role="button"
+      tabIndex={0}
+      onClick={onOpen}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault()
+          onOpen()
+        }
+      }}
+      aria-busy={isBusy}
+    >
+      <header className={styles.planCardHeader}>
+        <h3 className={styles.planCardTitle}>{plan.title}</h3>
+        <div className={styles.planCardActions}>
+          <button
+            type="button"
+            className={styles.iconButton}
+            onClick={handleRename}
+            aria-label="Renomear plano"
+            title="Renomear"
+            disabled={isBusy}
+          >
+            <Pencil size={16} />
+          </button>
+          <button
+            type="button"
+            className={`${styles.iconButton} ${styles.iconButtonDanger}`}
+            onClick={handleDelete}
+            aria-label="Excluir plano"
+            title="Excluir"
+            disabled={isBusy}
+          >
+            <Trash2 size={16} />
+          </button>
+        </div>
+      </header>
+
+      {jobLabel ? (
+        <div className={styles.planCardMetaLine}>
+          <Briefcase size={14} />
+          <span>{jobLabel}</span>
+        </div>
+      ) : null}
+
+      <div className={styles.planCardMetaLine}>
+        <Calendar size={14} />
+        <span>Criado em {formatDate(plan.createdAt)}</span>
+      </div>
+
+      <div className={styles.planCardProgressBlock}>
+        <div className={styles.planCardProgressLabels}>
+          <span>{progress}% concluído</span>
+          <span>
+            {completedModules}/{totalModules} módulos
+          </span>
+        </div>
+        <div className={styles.progressTrack} aria-hidden="true">
+          <div className={styles.progressFill} style={{ width: `${progress}%` }} />
+        </div>
+      </div>
+    </article>
+  )
+}
+
+type PlanDetailViewProps = {
+  plan: StudyPlan
+  openModuleId: string | undefined
+  onOpenModule: (id: string | undefined) => void
+  onBack: () => void
+  onToggleTask: (planId: string, moduleId: string, taskId: string) => void
+}
+
+function PlanDetailView({ plan, openModuleId, onOpenModule, onBack, onToggleTask }: PlanDetailViewProps) {
+  const totalModules = plan.modules.length
+  const completedModules = plan.modules.filter(
+    (mod) => mod.tasks.length > 0 && mod.tasks.every((task) => task.done),
+  ).length
+  const selectedOpenModuleId = openModuleId === undefined ? plan.modules[0]?.id ?? '' : openModuleId
+  const jobLabel = [plan.jobTitle, plan.companyName].filter(Boolean).join(' · ')
+
+  return (
+    <div className={styles.content}>
+      <PageContainer className={styles.expandedContainer}>
+        <div className={styles.pageStack}>
+          <button type="button" className={styles.backButton} onClick={onBack}>
+            <ArrowLeft size={16} />
+            Voltar aos planos
+          </button>
+
+          <PageHeader
+            title={plan.title}
+            description={jobLabel || 'Plano personalizado de estudos'}
+          />
 
           <section className={styles.summaryCards} aria-label="Resumo">
             <div className={`${styles.summaryCard} ${styles.cardGlass}`}>
@@ -54,48 +295,46 @@ export default function PlanoEstudosPage() {
                 <BookOpen size={20} />
               </div>
               <div className={styles.summaryMeta}>
-                <div className={styles.summaryBig}>{plans.length}</div>
+                <div className={styles.summaryBig}>{totalModules}</div>
                 <div className={styles.summarySmall}>Skills a desenvolver</div>
               </div>
             </div>
           </section>
 
-          {!isLoading && plans.length === 0 ? (
+          {plan.modules.length === 0 ? (
             <section className={styles.emptyState} aria-label="Plano vazio">
-              Nenhum plano de estudos gerado ainda.
+              Nenhum módulo neste plano — você já domina todas as skills exigidas pela vaga.
             </section>
-          ) : null}
-
-          {plans.length > 0 ? (
-            <section className={styles.skillsShell} aria-label="Plano de estudos">
+          ) : (
+            <section className={styles.skillsShell} aria-label="Módulos do plano">
               <div className={styles.skillPlanList}>
-                {plans.map((plan) => {
-                  const isOpen = plan.id === selectedOpenPlanId
-                  const completedPlanTasks = plan.tasks.filter((task) => task.done).length
-                  const progressPercentage = plan.tasks.length
-                    ? Math.round((completedPlanTasks / plan.tasks.length) * 100)
+                {plan.modules.map((moduleEntry) => {
+                  const isOpen = moduleEntry.id === selectedOpenModuleId
+                  const completedTasks = moduleEntry.tasks.filter((task) => task.done).length
+                  const progressPercentage = moduleEntry.tasks.length
+                    ? Math.round((completedTasks / moduleEntry.tasks.length) * 100)
                     : 0
                   const priorityClass =
-                    plan.priority === 'media'
+                    moduleEntry.priority === 'media'
                       ? styles.priorityMedia
-                      : styles[`priority${plan.priority}`]
+                      : styles[`priority${moduleEntry.priority}`]
 
                   return (
-                    <div key={plan.id} className={styles.skillPlanCard}>
+                    <div key={moduleEntry.id} className={styles.skillPlanCard}>
                       <button
                         type="button"
                         className={styles.skillPlanHeader}
-                        onClick={() => setOpenPlanId(isOpen ? '' : plan.id)}
+                        onClick={() => onOpenModule(isOpen ? '' : moduleEntry.id)}
                       >
                         <div>
                           <span className={`${styles.skillBadge} ${priorityClass}`}>
-                            Prioridade {plan.priority === 'media' ? 'média' : plan.priority}
+                            Prioridade {moduleEntry.priority === 'media' ? 'média' : moduleEntry.priority}
                           </span>
-                          <div className={styles.skillPlanTitle}>{plan.name}</div>
+                          <div className={styles.skillPlanTitle}>{moduleEntry.name}</div>
                         </div>
 
                         <div className={styles.skillPlanMeta}>
-                          <span>{completedPlanTasks}/{plan.tasks.length} concluído</span>
+                          <span>{completedTasks}/{moduleEntry.tasks.length} concluído</span>
                           <span className={styles.expandIcon}>{isOpen ? '-' : '+'}</span>
                         </div>
                       </button>
@@ -107,14 +346,14 @@ export default function PlanoEstudosPage() {
                         />
                       </div>
 
-                      {isOpen && plan.tasks.length > 0 ? (
+                      {isOpen && moduleEntry.tasks.length > 0 ? (
                         <div className={styles.skillTaskList}>
-                          {plan.tasks.map((task) => (
+                          {moduleEntry.tasks.map((task) => (
                             <button
                               key={task.id}
                               type="button"
                               className={`${styles.skillTaskItem} ${task.done ? styles.taskDone : ''}`}
-                              onClick={() => toggleTask(plan.id, task.id)}
+                              onClick={() => onToggleTask(plan.id, moduleEntry.id, task.id)}
                             >
                               {task.title}
                             </button>
@@ -126,7 +365,7 @@ export default function PlanoEstudosPage() {
                 })}
               </div>
             </section>
-          ) : null}
+          )}
         </div>
       </PageContainer>
     </div>

--- a/frontend/src/app/plano-estudos/plano-estudos.module.css
+++ b/frontend/src/app/plano-estudos/plano-estudos.module.css
@@ -297,3 +297,122 @@
     grid-template-columns: 1fr;
   }
 }
+
+.planGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 1.25rem;
+  margin-top: 0.5rem;
+}
+
+.planCard {
+  display: grid;
+  gap: 0.75rem;
+  padding: 1.25rem;
+  border-radius: 1.25rem;
+  background: var(--color-bg-card-dark);
+  border: 1px solid var(--color-border-shell-inner);
+  cursor: pointer;
+  transition: transform var(--transition-default), border-color var(--transition-default), background var(--transition-default);
+  outline: none;
+}
+
+.planCard:hover,
+.planCard:focus-visible {
+  transform: translateY(-2px);
+  border-color: color-mix(in srgb, var(--color-ring-focus) 35%, transparent);
+  background: color-mix(in srgb, var(--color-bg-card-dark) 80%, transparent);
+}
+
+.planCardHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.planCardTitle {
+  font-size: 1.05rem;
+  font-weight: 800;
+  color: var(--color-text-primary);
+  margin: 0;
+  line-height: 1.3;
+}
+
+.planCardActions {
+  display: flex;
+  gap: 0.35rem;
+  flex-shrink: 0;
+}
+
+.iconButton {
+  width: 30px;
+  height: 30px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid var(--color-border-shell-inner);
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition: background var(--transition-default), color var(--transition-default);
+}
+
+.iconButton:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.12);
+  color: var(--color-text-primary);
+}
+
+.iconButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.iconButtonDanger:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--color-priority-high) 22%, transparent);
+  color: var(--color-priority-high-text);
+}
+
+.planCardMetaLine {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  color: var(--color-text-muted);
+  font-size: 0.85rem;
+}
+
+.planCardProgressBlock {
+  display: grid;
+  gap: 0.45rem;
+  margin-top: 0.25rem;
+}
+
+.planCardProgressLabels {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+  font-weight: 600;
+}
+
+.backButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  align-self: flex-start;
+  background: transparent;
+  border: 1px solid var(--color-border-shell-inner);
+  color: var(--color-text-primary);
+  padding: 0.5rem 0.85rem;
+  border-radius: 0.75rem;
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 0.9rem;
+  transition: background var(--transition-default), border-color var(--transition-default);
+}
+
+.backButton:hover {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: color-mix(in srgb, var(--color-ring-focus) 30%, transparent);
+}

--- a/frontend/src/app/progresso/page.tsx
+++ b/frontend/src/app/progresso/page.tsx
@@ -29,27 +29,40 @@ function startOfDay(date: Date) {
 export default function ProgressoPage() {
   const { plans } = useStudyPlan()
 
-  const allTasks = plans.flatMap((plan) =>
-    plan.tasks.map((task) => ({
-      ...task,
+  const allModules = plans.flatMap((plan) =>
+    plan.modules.map((moduleEntry) => ({
+      ...moduleEntry,
       planId: plan.id,
-      planName: plan.name,
+      planTitle: plan.title,
+    })),
+  )
+
+  const allTasks = allModules.flatMap((moduleEntry) =>
+    moduleEntry.tasks.map((task) => ({
+      ...task,
+      planId: moduleEntry.planId,
+      moduleId: moduleEntry.id,
+      moduleName: moduleEntry.name,
     })),
   )
 
   const totalTasks = allTasks.length
   const completedTasks = allTasks.filter((task) => task.done).length
-  const totalSkills = plans.length
-  const dominatedSkills = plans.filter((plan) => plan.tasks.length > 0 && plan.tasks.every((task) => task.done)).length
+  const totalSkills = allModules.length
+  const dominatedSkills = allModules.filter(
+    (moduleEntry) => moduleEntry.tasks.length > 0 && moduleEntry.tasks.every((task) => task.done),
+  ).length
   const dominatedPercent = totalSkills > 0 ? Math.round((dominatedSkills / totalSkills) * 100) : 0
 
-  const skillProgress: SkillProgress[] = plans.map((plan) => {
-    const completedPlanTasks = plan.tasks.filter((task) => task.done).length
-    const percent = plan.tasks.length ? Math.round((completedPlanTasks / plan.tasks.length) * 100) : 0
+  const skillProgress: SkillProgress[] = allModules.map((moduleEntry) => {
+    const completedModuleTasks = moduleEntry.tasks.filter((task) => task.done).length
+    const percent = moduleEntry.tasks.length
+      ? Math.round((completedModuleTasks / moduleEntry.tasks.length) * 100)
+      : 0
     const status = percent >= 100 ? 'concluído' : percent >= 40 ? 'em andamento' : 'iniciando'
 
     return {
-      name: plan.name,
+      name: `${moduleEntry.name} · ${moduleEntry.planTitle}`,
       percent,
       status,
     }

--- a/frontend/src/contexts/StudyPlanContext.tsx
+++ b/frontend/src/contexts/StudyPlanContext.tsx
@@ -1,9 +1,9 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react'
-import { apiGet, apiPatch } from '../services/api'
+import { apiDelete, apiGet, apiPatch } from '../services/api'
 
 type TaskKind = 'subskill' | 'module'
 
-type StudyTask = {
+export type StudyTask = {
   id: string
   title: string
   done: boolean
@@ -11,11 +11,23 @@ type StudyTask = {
   kind: TaskKind
 }
 
-type SkillPlan = {
+export type SkillModule = {
   id: string
   name: string
   priority: 'alta' | 'media' | 'baixa'
   tasks: StudyTask[]
+}
+
+export type StudyPlan = {
+  id: string
+  title: string
+  jobId: string
+  jobTitle?: string
+  companyName?: string
+  createdAt: string
+  updatedAt: string
+  status: string
+  modules: SkillModule[]
 }
 
 type StudyPlanItemSkillResponse = {
@@ -39,21 +51,28 @@ type StudyPlanItemResponse = {
 type StudyPlanResponse = {
   id: string
   job_id: string
+  title: string
+  job_title?: string | null
+  company_name?: string | null
   status: string
+  created_at: string
+  updated_at: string
   items: StudyPlanItemResponse[]
 }
 
 interface StudyPlanContextValue {
-  plans: SkillPlan[]
+  plans: StudyPlan[]
   isLoading: boolean
   error: string
   reloadPlans: () => Promise<void>
-  toggleTask: (planId: string, taskId: string) => void
+  toggleTask: (planId: string, moduleId: string, taskId: string) => void
+  renamePlan: (planId: string, title: string) => Promise<void>
+  deletePlan: (planId: string) => Promise<void>
 }
 
 const StudyPlanContext = createContext<StudyPlanContextValue | undefined>(undefined)
 
-function mapPriority(priority: StudyPlanItemResponse['priority']): SkillPlan['priority'] {
+function mapPriority(priority: StudyPlanItemResponse['priority']): SkillModule['priority'] {
   return priority === 'required' ? 'alta' : 'media'
 }
 
@@ -95,19 +114,27 @@ function mapItemTasks(item: StudyPlanItemResponse): StudyTask[] {
   ]
 }
 
-function mapApiPlans(apiPlans: StudyPlanResponse[]): SkillPlan[] {
-  return apiPlans.flatMap((plan) =>
-    plan.items.map((item) => ({
+function mapApiPlans(apiPlans: StudyPlanResponse[]): StudyPlan[] {
+  return apiPlans.map((plan) => ({
+    id: plan.id,
+    title: plan.title,
+    jobId: plan.job_id,
+    jobTitle: plan.job_title ?? undefined,
+    companyName: plan.company_name ?? undefined,
+    createdAt: plan.created_at,
+    updatedAt: plan.updated_at,
+    status: plan.status,
+    modules: plan.items.map((item) => ({
       id: item.id,
       name: item.skill_name,
       priority: mapPriority(item.priority),
       tasks: mapItemTasks(item),
     })),
-  )
+  }))
 }
 
 export function StudyPlanProvider({ children }: { children: React.ReactNode }) {
-  const [plans, setPlans] = useState<SkillPlan[]>([])
+  const [plans, setPlans] = useState<StudyPlan[]>([])
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState('')
 
@@ -150,9 +177,10 @@ export function StudyPlanProvider({ children }: { children: React.ReactNode }) {
     }
   }, [reloadPlans])
 
-  const toggleTask = useCallback((planId: string, taskId: string) => {
+  const toggleTask = useCallback((planId: string, moduleId: string, taskId: string) => {
     const plan = plans.find((currentPlan) => currentPlan.id === planId)
-    const task = plan?.tasks.find((currentTask) => currentTask.id === taskId)
+    const moduleEntry = plan?.modules.find((currentModule) => currentModule.id === moduleId)
+    const task = moduleEntry?.tasks.find((currentTask) => currentTask.id === taskId)
     if (!task) {
       return
     }
@@ -164,13 +192,20 @@ export function StudyPlanProvider({ children }: { children: React.ReactNode }) {
           ? currentPlan
           : {
               ...currentPlan,
-              tasks: currentPlan.tasks.map((currentTask) =>
-                currentTask.id !== taskId
-                  ? currentTask
+              modules: currentPlan.modules.map((currentModule) =>
+                currentModule.id !== moduleId
+                  ? currentModule
                   : {
-                      ...currentTask,
-                      done: nextDone,
-                      doneAt: nextDone ? new Date().toISOString() : undefined,
+                      ...currentModule,
+                      tasks: currentModule.tasks.map((currentTask) =>
+                        currentTask.id !== taskId
+                          ? currentTask
+                          : {
+                              ...currentTask,
+                              done: nextDone,
+                              doneAt: nextDone ? new Date().toISOString() : undefined,
+                            },
+                      ),
                     },
               ),
             },
@@ -186,8 +221,8 @@ export function StudyPlanProvider({ children }: { children: React.ReactNode }) {
       status: nextDone ? 'completed' : 'pending',
     })
       .then(() => {
-        // Completing every topic marks the module skill as known, so refresh
-        // to reflect the updated module/skill state coming from the backend.
+        // Completing a module marks the skill as known across every plan, so
+        // refresh to surface the propagated state coming from the backend.
         void reloadPlans()
       })
       .catch(() => {
@@ -195,9 +230,19 @@ export function StudyPlanProvider({ children }: { children: React.ReactNode }) {
       })
   }, [plans, reloadPlans])
 
+  const renamePlan = useCallback(async (planId: string, title: string) => {
+    await apiPatch(`/study-plans/${planId}`, { title })
+    await reloadPlans()
+  }, [reloadPlans])
+
+  const deletePlan = useCallback(async (planId: string) => {
+    await apiDelete(`/study-plans/${planId}`)
+    await reloadPlans()
+  }, [reloadPlans])
+
   const value = useMemo(
-    () => ({ plans, isLoading, error, reloadPlans, toggleTask }),
-    [plans, isLoading, error, reloadPlans, toggleTask],
+    () => ({ plans, isLoading, error, reloadPlans, toggleTask, renamePlan, deletePlan }),
+    [plans, isLoading, error, reloadPlans, toggleTask, renamePlan, deletePlan],
   )
 
   return <StudyPlanContext.Provider value={value}>{children}</StudyPlanContext.Provider>


### PR DESCRIPTION
…e planos

- StudyPlan agora tem campo title (default: "Plano para {Cargo} - {Empresa}")
- Endpoints PATCH /study-plans/{id} para renomear e DELETE para excluir
- Ao concluir um modulo, o mesmo skill_id e marcado como concluido em outros planos do usuario (alinha com a skill ja adicionada ao perfil)
- Pagina de plano de estudos agora lista planos como cards com nome, vaga/empresa, data, progresso e quantidade de modulos
- Clicar no card abre o detalhe com os modulos (mesmo fluxo de hoje)
- Apos gerar plano, /plano-estudos?jobId=X abre o plano correspondente