### PR TITLE
fix(auth): corrige IndentationError em change-password

### DIFF
--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -162,16 +162,10 @@ def change_password(
 		)
 
 	if verify_password(payload.new_password, str(current_user.password)):
-	raise HTTPException(
-		status_code=status.HTTP_400_BAD_REQUEST,
-		detail="A nova senha não pode ser igual à senha atual.",
-	)
-
-user_repo.update_user_password(
-	db=db,
-	user=current_user,
-	hashed_password=hash_password(payload.new_password),
-)	
+		raise HTTPException(
+			status_code=status.HTTP_400_BAD_REQUEST,
+			detail="A nova senha não pode ser igual à senha atual.",
+		)
 
 	user_repo.update_user_password(
 		db=db,


### PR DESCRIPTION
Corrige a indentação do bloco que valida se a nova senha é igual à atual e remove a chamada duplicada de update_user_password que estava com indentação inválida, causando falha no deploy do backend.
